### PR TITLE
Add JSON-driven content management layer

### DIFF
--- a/content.json
+++ b/content.json
@@ -1,0 +1,97 @@
+{
+  "hero": {
+    "title": "Hi, I\u2019m Dekel Hillel",
+    "subtitleHtml": "Senior Product Designer at <strong>Ownera</strong> <br>&amp; Lecturer at <strong>Bezalel Academy</strong>"
+  },
+  "previousRoles": [
+    {
+      "companyName": "placer.ai",
+      "companyUrl": "http://placer.ai",
+      "linkClass": "link-3",
+      "companyStrongClass": "social-link",
+      "titleHtml": "Product Designer<br>",
+      "titleClass": "text-block",
+      "years": "2021-2022",
+      "yearsClass": "span-opacity"
+    },
+    {
+      "companyName": "pay.com",
+      "companyUrl": "http://pay.com",
+      "linkClass": "link",
+      "companyStrongClass": "social-link",
+      "titleHtml": "Principal Product Designer<br>",
+      "years": "2020-2021",
+      "yearsClass": "span-opacity"
+    },
+    {
+      "companyName": "SimilarWeb",
+      "companyUrl": "http://similarweb.com",
+      "linkClass": "link-2",
+      "companyStrongClass": "social-link",
+      "titleHtml": "Product Designer<br>",
+      "years": "2018-2020",
+      "yearsClass": "span-opacity"
+    }
+  ],
+  "socialLinks": [
+    {
+      "label": "LinkedIn",
+      "url": "https://www.linkedin.com/in/dekelhillel/",
+      "id": "w-node-_9dd94fb2-377d-ab9b-3ee9-b7d3af805953-0f067df9",
+      "className": "social-link"
+    },
+    {
+      "label": "Instagram",
+      "url": "https://www.instagram.com/dekelhillel/",
+      "id": "w-node-_61710b3e-f786-c03e-e579-dd3a7a0793d8-0f067df9",
+      "className": "social-link"
+    }
+  ],
+  "heroImages": [
+    {
+      "src": "images/Placer.webp",
+      "loading": "eager",
+      "alt": "Placer.ai platform mockup",
+      "width": 680,
+      "srcset": "images/Placer-p-500.jpg 500w, images/Placer-p-800.jpg 800w, images/Placer-p-1080.jpg 1080w, images/Placer.webp 1360w",
+      "sizes": "(max-width: 479px) 87vw, (max-width: 767px) 92vw, (max-width: 991px) 94vw, 44vw",
+      "classList": [
+        "image-hero",
+        "is-hiding"
+      ],
+      "dataAttributes": {
+        "data-w-id": "9785e105-9bc2-aeb4-70ef-be241f666759"
+      }
+    },
+    {
+      "src": "images/Pay.webp",
+      "loading": "eager",
+      "alt": "Pay.com Platform Mockup",
+      "width": 680,
+      "srcset": "images/Pay-p-500.jpg 500w, images/Pay-p-800.jpg 800w, images/Pay-p-1080.jpg 1080w, images/Pay.webp 1360w",
+      "sizes": "(max-width: 479px) 87vw, (max-width: 767px) 92vw, (max-width: 991px) 94vw, 44vw",
+      "classList": [
+        "image-hero",
+        "is-hiding"
+      ],
+      "dataAttributes": {
+        "data-w-id": "0888242b-f7c5-282a-365e-d2f5521cae2a"
+      }
+    },
+    {
+      "src": "images/Balance.webp",
+      "loading": "eager",
+      "alt": "Balance app mockup",
+      "width": 680,
+      "srcset": "images/Balance-p-500.jpg 500w, images/Balance-p-800.jpg 800w, images/Balance-p-1080.jpg 1080w, images/Balance.webp 1360w",
+      "sizes": "(max-width: 479px) 87vw, (max-width: 767px) 92vw, (max-width: 991px) 94vw, 44vw",
+      "classList": [
+        "image-hero",
+        "is-hiding"
+      ],
+      "dataAttributes": {
+        "data-w-id": "e9eb1212-6140-ca06-51d7-a252654addbc"
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -52,53 +52,25 @@
         <div class="split-content hero-content">
           <a data-w-id="67189a1c-fac1-96c9-a4f8-da31ba7c303b" href="#" class="light-switch-button w-inline-block"><img src="images/Light-Button.svg" loading="lazy" data-w-id="267abc14-5dc1-ca46-780c-4ff2c17e1a05" alt="Light mode button"></a>
           <div class="title-wrapper">
-            <h1 class="heading">Hi, I’m Dekel Hillel</h1>
-            <p class="paragraph">Senior Product Designer at <strong>Ownera</strong> <br>&amp; Lecturer at <strong>Bezalel Academy</strong></p>
+            <h1 class="heading" id="hero-title"></h1>
+            <p class="paragraph" id="hero-subtitle"></p>
           </div>
           <div class="resume-content-wrapper">
             <div class="text-block-eyebrow _1">Previously</div>
-            <div class="split-title-position-wrapper">
-              <div class="text-block-body-16px">
-                <a href="http://placer.ai" target="_blank" class="link-3"><strong class="social-link">placer.ai</strong></a>
-              </div>
-              <div id="w-node-_868e74d6-6cb3-254f-f206-c3e15b9d4b33-0f067df9" class="flex-vertical gap-row-8px">
-                <div class="text-block">Product Designer<br></div>
-                <div><span class="span-opacity">2021-2022</span></div>
-              </div>
-            </div>
-            <div class="split-title-position-wrapper">
-              <div class="text-block-body-16px">
-                <a href="http://pay.com" target="_blank" class="link"><strong class="social-link">pay.com</strong></a>
-              </div>
-              <div class="flex-vertical gap-row-8px">
-                <div>Principal Product Designer<br></div>
-                <div><span class="span-opacity">2020-2021</span></div>
-              </div>
-            </div>
-            <div class="split-title-position-wrapper">
-              <div class="text-block-body-16px">
-                <a href="http://similarweb.com" target="_blank" class="link-2"><strong class="social-link">SimilarWeb</strong></a>
-              </div>
-              <div class="flex-vertical gap-row-8px">
-                <div>Product Designer<br></div>
-                <div><span class="span-opacity">2018-2020</span></div>
-              </div>
-            </div>
+            <div id="previous-roles"></div>
           </div>
           <div class="social-links-wrapper">
             <div class="text-block-eyebrow">Follow me</div>
-            <div class="split-title-social-links-wrapper">
-              <a id="w-node-_9dd94fb2-377d-ab9b-3ee9-b7d3af805953-0f067df9" href="https://www.linkedin.com/in/dekelhillel/" target="_blank" class="social-link">LinkedIn</a>
-              <a id="w-node-_61710b3e-f786-c03e-e579-dd3a7a0793d8-0f067df9" href="https://www.instagram.com/dekelhillel/" target="_blank" class="social-link">Instagram</a>
-            </div>
+            <div class="split-title-social-links-wrapper" id="social-links"></div>
           </div>
         </div>
-        <div class="split-content hero-image"><img src="images/Placer.webp" loading="eager" data-w-id="9785e105-9bc2-aeb4-70ef-be241f666759" width="680" alt="Placer.ai platform mockup" srcset="images/Placer-p-500.jpg 500w, images/Placer-p-800.jpg 800w, images/Placer-p-1080.jpg 1080w, images/Placer.webp 1360w" sizes="(max-width: 479px) 87vw, (max-width: 767px) 92vw, (max-width: 991px) 94vw, 44vw" class="image-hero is-hiding"><img src="images/Pay.webp" loading="eager" data-w-id="0888242b-f7c5-282a-365e-d2f5521cae2a" width="680" alt="Pay.com Platform Mockup" srcset="images/Pay-p-500.jpg 500w, images/Pay-p-800.jpg 800w, images/Pay-p-1080.jpg 1080w, images/Pay.webp 1360w" sizes="(max-width: 479px) 87vw, (max-width: 767px) 92vw, (max-width: 991px) 94vw, 44vw" class="image-hero is-hiding"><img src="images/Balance.webp" loading="eager" data-w-id="e9eb1212-6140-ca06-51d7-a252654addbc" width="680" alt="Balance app mockup" srcset="images/Balance-p-500.jpg 500w, images/Balance-p-800.jpg 800w, images/Balance-p-1080.jpg 1080w, images/Balance.webp 1360w" sizes="(max-width: 479px) 87vw, (max-width: 767px) 92vw, (max-width: 991px) 94vw, 44vw" class="image-hero is-hiding">
+        <div class="split-content hero-image" id="hero-image-container">
           <div data-w-id="492876ca-ab6b-701a-ec31-2f870e8a2ef5" style="width:0px" class="load-bar"></div>
         </div>
       </div>
     </div>
   </div>
+  <script src="js/content.js"></script>
   <script src="js/carousel.js"></script>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=63a5e52b2cb21cd6330d619a" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="js/webflow.js" type="text/javascript"></script>

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -1,53 +1,75 @@
 // Custom carousel logic for Dekel Hillel's portfolio site
 //
-// This script replaces the broken Webflow carousel implementation with a
-// straightforward mechanism that cycles through hero images on a timer.
-// It assumes that the hero section contains multiple images with the
-// class name `image-hero` and that only one image should be visible at
-// a time. Each image is displayed for five seconds before transitioning
-// to the next one. If users add or remove images from the hero section
-// they will automatically be included in the rotation.
+// The carousel relies on hero images being injected dynamically by
+// `content.js`. To avoid race conditions we listen for a custom
+// `content:ready` event and fall back to a MutationObserver if no images
+// exist when the DOM is ready.
 
 (() => {
-  /**
-   * Hide all hero images except the one at the specified index.
-   *
-   * @param {HTMLElement[]} images - Array of hero image elements.
-   * @param {number} index - Index of the image to show.
-   */
+  let intervalId = null;
+  let observer = null;
+
   function showSlide(images, index) {
     images.forEach((img, i) => {
-      // Use inline styles rather than classes to avoid conflicts with
-      // Webflow-generated styles. Only the current image should be
-      // displayed; all others are hidden.
       img.style.display = i === index ? 'block' : 'none';
     });
   }
 
-  /**
-   * Initialise the carousel once the DOM is ready. This function locates
-   * all images with the class `image-hero`, shows the first image, and
-   * sets up a timer to automatically cycle through them.
-   */
-  function initCarousel() {
-    const images = Array.from(document.querySelectorAll('.image-hero'));
-    if (images.length === 0) {
-      // No hero images found; nothing to initialise.
-      return;
+  function startRotation(images) {
+    if (intervalId) {
+      clearInterval(intervalId);
     }
 
     let currentIndex = 0;
     showSlide(images, currentIndex);
 
-    // Cycle through slides every 5 seconds. Use modulo to wrap
-    // around to the first slide when reaching the end.
-    setInterval(() => {
+    if (images.length <= 1) {
+      return;
+    }
+
+    intervalId = setInterval(() => {
       currentIndex = (currentIndex + 1) % images.length;
       showSlide(images, currentIndex);
     }, 5000);
   }
 
-  // Run the init function after DOMContentLoaded to ensure that
-  // all elements are available in the DOM.
-  document.addEventListener('DOMContentLoaded', initCarousel);
+  function initCarousel() {
+    const images = Array.from(document.querySelectorAll('.image-hero'));
+    if (images.length === 0) {
+      return false;
+    }
+
+    startRotation(images);
+
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+
+    return true;
+  }
+
+  function waitForImages() {
+    if (observer) {
+      return;
+    }
+
+    observer = new MutationObserver(() => {
+      if (initCarousel()) {
+        observer.disconnect();
+        observer = null;
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  function onDomReady() {
+    if (!initCarousel()) {
+      waitForImages();
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', onDomReady);
+  document.addEventListener('content:ready', initCarousel);
 })();

--- a/js/content.js
+++ b/js/content.js
@@ -1,0 +1,191 @@
+// Content management bootstrap for Dekel Hillel's portfolio site
+//
+// This script loads structured content from `content.json` and injects it
+// into the static Webflow markup. The goal is to let non-technical editors
+// update the copy, links and imagery by editing a single JSON file instead
+// of touching the HTML. Once the content is in place we emit a custom
+// `content:ready` event so that other scripts (like the hero carousel)
+// can react to the dynamically added elements.
+
+(function () {
+  const CONTENT_PATH = 'content.json';
+
+  function setTextContent(selector, text, useHtml = false) {
+    const element = document.querySelector(selector);
+    if (!element || text == null) {
+      return;
+    }
+
+    if (useHtml) {
+      element.innerHTML = text;
+    } else {
+      element.textContent = text;
+    }
+  }
+
+  function buildPreviousRoles(roles) {
+    const container = document.querySelector('#previous-roles');
+    if (!container || !Array.isArray(roles)) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    roles.forEach((role) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'split-title-position-wrapper';
+
+      const linkWrapper = document.createElement('div');
+      linkWrapper.className = 'text-block-body-16px';
+
+      const link = document.createElement('a');
+      link.href = role.companyUrl || '#';
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      if (role.linkClass) {
+        link.className = role.linkClass;
+      }
+
+      const strong = document.createElement('strong');
+      strong.textContent = role.companyName || '';
+      strong.className = role.companyStrongClass || '';
+      link.appendChild(strong);
+
+      linkWrapper.appendChild(link);
+      wrapper.appendChild(linkWrapper);
+
+      const detailsWrapper = document.createElement('div');
+      detailsWrapper.className = 'flex-vertical gap-row-8px';
+
+      const title = document.createElement('div');
+      if (role.titleClass) {
+        title.className = role.titleClass;
+      }
+      if (role.titleHtml) {
+        title.innerHTML = role.titleHtml;
+      } else if (role.title) {
+        title.textContent = role.title;
+      }
+      detailsWrapper.appendChild(title);
+
+      const years = document.createElement('div');
+      const yearsSpan = document.createElement('span');
+      if (role.yearsClass) {
+        yearsSpan.className = role.yearsClass;
+      }
+      if (role.years) {
+        yearsSpan.textContent = role.years;
+      }
+      years.appendChild(yearsSpan);
+      detailsWrapper.appendChild(years);
+
+      wrapper.appendChild(detailsWrapper);
+      container.appendChild(wrapper);
+    });
+  }
+
+  function buildSocialLinks(links) {
+    const container = document.querySelector('#social-links');
+    if (!container || !Array.isArray(links)) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    links.forEach((linkData) => {
+      const link = document.createElement('a');
+      link.href = linkData.url || '#';
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = linkData.label || '';
+
+      if (linkData.id) {
+        link.id = linkData.id;
+      }
+      if (linkData.className) {
+        link.className = linkData.className;
+      }
+
+      container.appendChild(link);
+    });
+  }
+
+  function buildHeroImages(images) {
+    const container = document.querySelector('#hero-image-container');
+    if (!container || !Array.isArray(images)) {
+      return;
+    }
+
+    const loadBar = container.querySelector('.load-bar');
+    const existingImages = container.querySelectorAll('.image-hero');
+    existingImages.forEach((image) => image.remove());
+
+    images.forEach((imageData) => {
+      const img = document.createElement('img');
+
+      if (Array.isArray(imageData.classList) && imageData.classList.length) {
+        img.className = imageData.classList.join(' ');
+      }
+
+      if (imageData.loading) {
+        img.loading = imageData.loading;
+      }
+
+      if (imageData.alt) {
+        img.alt = imageData.alt;
+      }
+
+      if (imageData.width) {
+        img.width = imageData.width;
+      }
+
+      if (imageData.src) {
+        img.src = imageData.src;
+      }
+
+      if (imageData.srcset) {
+        img.setAttribute('srcset', imageData.srcset);
+      }
+
+      if (imageData.sizes) {
+        img.setAttribute('sizes', imageData.sizes);
+      }
+
+      if (imageData.dataAttributes) {
+        Object.entries(imageData.dataAttributes).forEach(([name, value]) => {
+          img.setAttribute(name, value);
+        });
+      }
+
+      if (loadBar) {
+        container.insertBefore(img, loadBar);
+      } else {
+        container.appendChild(img);
+      }
+    });
+  }
+
+  async function loadContent() {
+    try {
+      const response = await fetch(CONTENT_PATH, { cache: 'no-cache' });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const content = await response.json();
+
+      const hero = content.hero || {};
+      setTextContent('#hero-title', hero.title || '');
+      setTextContent('#hero-subtitle', hero.subtitleHtml || '', true);
+      buildPreviousRoles(content.previousRoles);
+      buildSocialLinks(content.socialLinks);
+      buildHeroImages(content.heroImages);
+
+      document.dispatchEvent(new Event('content:ready'));
+    } catch (error) {
+      console.error('Failed to load site content:', error);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', loadContent);
+})();


### PR DESCRIPTION
## Summary
- centralize hero copy, experience entries, social links, and hero imagery in a new `content.json` data file
- hydrate the homepage from JSON via `js/content.js`, emitting a `content:ready` signal once content loads
- harden the hero carousel so it waits for dynamically injected images before rotating

## Testing
- python -m json.tool content.json

------
https://chatgpt.com/codex/tasks/task_e_68cd62f4842083269a4328e4b9f0c888