### PR TITLE
Adjust Case Studies link font size

### DIFF
--- a/css/dekel-hillel.webflow.css
+++ b/css/dekel-hillel.webflow.css
@@ -123,6 +123,7 @@ p {
   border: none;
   box-shadow: none;
   padding: 8px 12px;
+  font-size: 14px;
   font-weight: 600;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- set the Case Studies top navigation link font size to 14px

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514f1c84e48326862e189db9188a68)