### PR TITLE
Add SimilarWeb Arena screenshot to 2019 work entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,6 +780,9 @@
           <a href="https://www.similarweb.com/" target="_blank" rel="noopener noreferrer">SimilarWeb</a> - Crafting data-heavy interfaces and intuitive user experiences for a high-scale market intelligence platform.
         </p>
         <div class="img-wrap ratio-3x2 reveal">
+          <img src="images/002-SimilarWeb.png" alt="SimilarWeb Arena onboarding screen for creating a competitive set of websites" loading="lazy" decoding="async">
+        </div>
+        <div class="img-wrap ratio-3x2 reveal">
           <img src="images/001-SimilarWeb.png" alt="SimilarWeb market intelligence platform showing data-heavy dashboard interface" loading="lazy" decoding="async">
         </div>
       </article>


### PR DESCRIPTION
## Summary
Adds the SimilarWeb Arena onboarding screenshot (`images/002-SimilarWeb.png`, uploaded to main earlier) to the 2019 SimilarWeb work entry, displayed above the existing dashboard image with the same 3:2 wrapper, lazy loading, and descriptive alt text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01318RZM4LgcuGDpgiJV44Jz

---
_Generated by [Claude Code](https://claude.ai/code/session_01318RZM4LgcuGDpgiJV44Jz)_