### PR TITLE
Keep hero text column centered across breakpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,8 +153,8 @@
     }
 
     .hero > * {
-      width: 760px;
-      max-width: 100%;
+      width: 100%;
+      max-width: 760px;
     }
 
     .hero h1 {
@@ -321,14 +321,6 @@
        TABLET  (below the 1237px card + 40px gutters)
     ============================================================ */
     @media (max-width: 1319px) {
-      .hero {
-        padding: 80px 0;
-      }
-
-      .hero > * {
-        width: 100%;
-      }
-
       .work {
         width: 100%;
         padding: 56px;


### PR DESCRIPTION
Use a single max-width column (width: 100%, max-width: 760px) inside the centered flex hero instead of a per-breakpoint width override, so the text block stays horizontally centered at every viewport size.


Claude-Session: https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB