### PR TITLE
Homepage polish: animated back-to-top button, hover states, image skeletons, and mobile fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,11 +344,17 @@
        the user starts scrolling, and back when they return to top.
     ============================================================ */
     .dot-rail {
+      /* per-breakpoint tuning happens through these variables */
+      --fab-edge: 40px;   /* offset from the viewport corner */
+      --fab-size: 48px;   /* expanded button size */
+      --fab-dot:  24px;   /* resting dot size */
+      --fab-icon: 28.8px; /* chevron size */
+
       position: fixed;
-      right: 40px;
-      bottom: 40px;
-      width: 48px;
-      height: 48px;
+      right: calc(var(--fab-edge) + env(safe-area-inset-right, 0px));
+      bottom: calc(var(--fab-edge) + env(safe-area-inset-bottom, 0px));
+      width: var(--fab-size);
+      height: var(--fab-size);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -360,8 +366,8 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 24px;
-      height: 24px;
+      width: var(--fab-dot);
+      height: var(--fab-dot);
       border-radius: 118.8px;
       border: none;
       background: #fff;
@@ -374,8 +380,8 @@
     }
 
     .back-dot svg {
-      width: 28.8px;
-      height: 28.8px;
+      width: var(--fab-icon);
+      height: var(--fab-icon);
       flex-shrink: 0;
       opacity: 0;
       transform: translateY(8px) scale(0.4);
@@ -385,8 +391,8 @@
     }
 
     .back-dot.expanded {
-      width: 48px;
-      height: 48px;
+      width: var(--fab-size);
+      height: var(--fab-size);
     }
 
     .back-dot.expanded svg {
@@ -427,7 +433,7 @@
       }
 
       .dot-rail {
-        display: none;
+        --fab-edge: 24px;
       }
     }
 
@@ -457,6 +463,13 @@
       .case-link span {
         flex: 1 0 0;
         min-width: 1px;
+      }
+
+      .dot-rail {
+        --fab-edge: 24px;
+        --fab-size: 40px;
+        --fab-dot:  20px;
+        --fab-icon: 24px;
       }
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -388,8 +388,9 @@
       }
 
       .hero {
-        min-height: 904px;
-        padding: 80px 16px;
+        min-height: 0;
+        justify-content: flex-start;
+        padding: 40px 16px 80px;
       }
 
       .hero h1 {

--- a/index.html
+++ b/index.html
@@ -186,6 +186,11 @@
       color: var(--text);
       text-decoration: underline;
       text-underline-position: from-font;
+      transition: text-decoration-color 0.2s ease;
+    }
+
+    .contact-links a:hover {
+      text-decoration-color: #FF0000;
     }
 
     /* ============================================================
@@ -251,6 +256,11 @@
       text-decoration: underline;
       text-underline-position: from-font;
       overflow-wrap: break-word;
+      transition: text-decoration-color 0.2s ease;
+    }
+
+    .case-link:hover span {
+      text-decoration-color: #FF0000;
     }
 
     .case-link svg {
@@ -264,6 +274,18 @@
       aspect-ratio: 1920 / 1280;
       border-radius: 16px;
       overflow: hidden;
+      position: relative;
+      background: #211c2a;  /* skeleton base while the image loads */
+    }
+
+    .shot::before {
+      /* skeleton shimmer sweep */
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(100deg, transparent 35%, rgba(255, 255, 255, 0.07) 50%, transparent 65%);
+      transform: translateX(-100%);
+      animation: shimmer 1.4s ease-in-out infinite;
     }
 
     .shot img {
@@ -271,6 +293,25 @@
       width: 100%;
       height: 100%;
       object-fit: cover;
+      position: relative;
+      opacity: 0;
+      transition: opacity 0.5s ease;
+    }
+
+    .shot.loaded {
+      background: none;
+    }
+
+    .shot.loaded::before {
+      content: none;
+    }
+
+    .shot.loaded img {
+      opacity: 1;
+    }
+
+    @keyframes shimmer {
+      100% { transform: translateX(100%); }
     }
 
     .note {
@@ -360,8 +401,13 @@
 
     @media (prefers-reduced-motion: reduce) {
       .back-dot,
-      .back-dot svg {
+      .back-dot svg,
+      .shot img {
         transition: none;
+      }
+
+      .shot::before {
+        animation: none;
       }
     }
 
@@ -529,6 +575,18 @@
       };
       window.addEventListener('scroll', onScroll, { passive: true });
       onScroll();
+
+      // Reveal images once loaded; the .shot wrapper shows a
+      // shimmering skeleton until then.
+      document.querySelectorAll('.shot img').forEach(function (img) {
+        var reveal = function () { img.closest('.shot').classList.add('loaded'); };
+        if (img.complete && img.naturalWidth > 0) {
+          reveal();
+        } else {
+          img.addEventListener('load', reveal);
+          img.addEventListener('error', reveal);
+        }
+      });
     })();
   </script>
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,11 @@
     html {
       scroll-behavior: smooth;
       background: var(--bg);
+      /* iOS Safari: block horizontal panning — body alone isn't enough */
+      overflow-x: hidden;
+      overflow-x: clip;
+      -webkit-text-size-adjust: 100%;
+      text-size-adjust: 100%;
     }
 
     body {
@@ -94,6 +99,7 @@
       font-size: 18px;
       line-height: 1.4;
       overflow-x: hidden;
+      overflow-x: clip;
       position: relative;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary
Follow-up polish on the redesigned homepage (#35):

**Layout fixes**
- Hero text column stays centered at every breakpoint (was hugging the left gutter on tablet widths)
- Mobile hero is top-aligned with 40px top padding, matching the updated Figma frame
- Fixed horizontal scrolling on iOS Safari (`overflow-x` on `html` + `body`, `text-size-adjust: 100%`)

**Back-to-top button (Figma `button-back-expend` component)**
- Rests as a white dot; springs into a 48px chevron button once the user scrolls, and collapses back at the top
- Fixed to the bottom-right corner, now visible on all breakpoints with per-size tuning via CSS variables: 40px insets on desktop, 24px on tablet/mobile, smaller 40px button on phones
- Respects iOS safe-area insets and `prefers-reduced-motion`

**Interaction states**
- Link hover: underline transitions to `#FF0000` (text stays white) on contact and case-study links
- Work images show a shimmering skeleton while loading, then fade in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_