### PR TITLE
Make the ColorBends hero glow visible

### DIFF
--- a/assets/hero-effects.js
+++ b/assets/hero-effects.js
@@ -24,7 +24,7 @@
     speed: 0.2,
     frequency: 1.0,
     noise: 0.15,
-    bandWidth: 0.14,
+    bandWidth: 1.0,
     iterations: 1,
     intensity: 1.3,
     transparent: true,


### PR DESCRIPTION
## Summary
The React Bits demo value (`bandWidth: 0.14`) capped the WebGL shader's color output at ~13% opacity — indistinguishable from the `#110F18` hero background, so only the dot grid was visible. Raising `bandWidth` to `1.0` renders soft indigo ribbons behind the dots while keeping the effect subtle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_