### PR TITLE
Back-to-top button: 24px corner offset on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
     ============================================================ */
     .dot-rail {
       /* per-breakpoint tuning happens through these variables */
-      --fab-edge: 40px;   /* offset from the viewport corner */
+      --fab-edge: 24px;   /* offset from the viewport corner */
       --fab-size: 48px;   /* expanded button size */
       --fab-dot:  24px;   /* resting dot size */
       --fab-icon: 28.8px; /* chevron size */
@@ -449,10 +449,6 @@
         width: 100%;
         padding: 56px;
       }
-
-      .dot-rail {
-        --fab-edge: 24px;
-      }
     }
 
     /* ============================================================
@@ -493,7 +489,6 @@
       }
 
       .dot-rail {
-        --fab-edge: 24px;
         --fab-size: 40px;
         --fab-dot:  20px;
         --fab-icon: 24px;


### PR DESCRIPTION
## Summary
Desktop's back-to-top button now sits 24px from the right and bottom edges, matching tablet/mobile. The now-redundant per-breakpoint `--fab-edge` overrides were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_