### PR TITLE
Match ColorBends positioning and sharpness to the React Bits demo

### DIFF
--- a/assets/hero-effects.js
+++ b/assets/hero-effects.js
@@ -14,10 +14,9 @@
 
   var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   var DPR = Math.min(window.devicePixelRatio || 1, 2);
-  /* The shader is soft gradients + grain — rendering it at 1x and
-     letting the browser upscale is visually identical but cuts the
-     per-frame fragment work up to 4x on retina/mobile screens. */
-  var SHADER_DPR = 1;
+  /* Match the original renderer: the shader canvas is DPR-scaled so
+     the noise grain stays crisp on retina screens. */
+  var SHADER_DPR = DPR;
 
   /* ==========================================================
      ColorBends — props from the React Bits homepage hero demo
@@ -31,6 +30,7 @@
     bandWidth: 1.0,
     iterations: 1,
     intensity: 1.3,
+    fadeTop: 0.75,
     transparent: true,
     autoRotate: 0,
     scale: 1,
@@ -71,6 +71,7 @@
     'uniform int uIterations;',
     'uniform float uIntensity;',
     'uniform float uBandWidth;',
+    'uniform float uFadeTop;',
     'varying vec2 vUv;',
     '',
     'void main() {',
@@ -139,6 +140,12 @@
     '',
     '  col *= uIntensity;',
     '',
+    '  if (uFadeTop > 0.0001) {',
+    '    float fade = 1.0 - smoothstep(1.0 - uFadeTop, 1.0, vUv.y);',
+    '    col *= fade;',
+    '    a *= fade;',
+    '  }',
+    '',
     '  if (uNoise > 0.0001) {',
     '    float n = fract(sin(dot(gl_FragCoord.xy + vec2(uTime), vec2(12.9898, 78.233))) * 43758.5453123);',
     '    col += (n - 0.5) * uNoise;',
@@ -206,7 +213,7 @@
     var U = {};
     ['uCanvas', 'uTime', 'uSpeed', 'uRot', 'uColorCount', 'uColors', 'uTransparent',
      'uScale', 'uFrequency', 'uWarpStrength', 'uPointer', 'uMouseInfluence',
-     'uParallax', 'uNoise', 'uIterations', 'uIntensity', 'uBandWidth'
+     'uParallax', 'uNoise', 'uIterations', 'uIntensity', 'uBandWidth', 'uFadeTop'
     ].forEach(function (name) { U[name] = gl.getUniformLocation(prog, name); });
 
     var colorData = new Float32Array(MAX_COLORS * 3);
@@ -230,6 +237,7 @@
     gl.uniform1i(U.uIterations, CB.iterations);
     gl.uniform1f(U.uIntensity, CB.intensity);
     gl.uniform1f(U.uBandWidth, CB.bandWidth);
+    gl.uniform1f(U.uFadeTop, CB.fadeTop);
 
     gl.clearColor(0, 0, 0, 0);
 


### PR DESCRIPTION
## Summary
Two fixes so the hero shader matches reactbits.dev:

- **fadeTop (missing prop):** the React Bits demo passes `fadeTop={0.75}`, which wasn't in the component source provided earlier. Added the uniform to the shader — output now fades toward the top so the glow concentrates in the lower half of the hero, matching the original composition.
- **DPR rendering:** the shader canvas is again scaled by `min(devicePixelRatio, 2)` like the original OGL renderer, so the noise grain is crisp on retina displays (it was rendered at 1x as a performance optimization, which read as blur).

Remaining parameter diff vs the demo (intentional): `bandWidth` is 1.0 instead of 0.14, since at 0.14 our port's glow was invisible against #110F18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_