### PR TITLE
Align meta descriptions with the hero copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>
-  <meta name="description" content="A Senior Product Designer focused on architecting complex B2B infrastructure from the ground up. An expert at translating high-scale data platforms into intuitive tools, with proven experience leading design at Ownera, Placer.ai, and SimilarWeb.">
+  <meta name="description" content="I'm a product designer who builds the foundations for complex products — most recently leading design at Ownera, after high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1 and sweating the details.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://dekelhillel.com/">
@@ -16,7 +16,7 @@
   <meta property="og:url"         content="https://dekelhillel.com/">
   <meta property="og:site_name"   content="Dekel Hillel">
   <meta property="og:title"       content="Dekel Hillel">
-  <meta property="og:description" content="A Senior Product Designer focused on architecting complex B2B infrastructure from the ground up. An expert at translating high-scale data platforms into intuitive tools, with proven experience leading design at Ownera, Placer.ai, and SimilarWeb.">
+  <meta property="og:description" content="I'm a product designer who builds the foundations for complex products — most recently leading design at Ownera, after high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1 and sweating the details.">
   <meta property="og:image"       content="https://dekelhillel.com/og-image.png">
   <meta property="og:image:width"  content="1200">
   <meta property="og:image:height" content="630">
@@ -26,9 +26,9 @@
   <!-- ── Twitter / X Card ────────────────────────────────────── -->
   <meta name="twitter:card"        content="summary_large_image">
   <meta name="twitter:title"       content="Dekel Hillel">
-  <meta name="twitter:description" content="A Senior Product Designer focused on architecting complex B2B infrastructure from the ground up.">
+  <meta name="twitter:description" content="A product designer who builds the foundations for complex products — most recently leading design at Ownera.">
   <meta name="twitter:image"       content="https://dekelhillel.com/og-image.png">
-  <meta name="twitter:image:alt"   content="Dekel Hillel, Senior Product Designer">
+  <meta name="twitter:image:alt"   content="Dekel Hillel, Product Designer">
 
   <!-- ── Theme color (mobile browser chrome) ─────────────────── -->
   <meta name="theme-color" content="#110f18">
@@ -45,8 +45,8 @@
     "@type": "Person",
     "name": "Dekel Hillel",
     "url": "https://dekelhillel.com",
-    "jobTitle": "Senior Product Designer",
-    "description": "A Senior Product Designer focused on architecting complex B2B infrastructure from the ground up.",
+    "jobTitle": "Product Designer",
+    "description": "A product designer who builds the foundations for complex products — most recently leading design at Ownera.",
     "sameAs": [
       "https://www.linkedin.com/in/dekelhillel/"
     ],


### PR DESCRIPTION
## Summary
The SEO/OG/Twitter descriptions and JSON-LD were written for the old site ("Senior Product Designer focused on architecting complex B2B infrastructure…"). They now mirror the hero's actual copy:

- **Search + OG description:** "I'm a product designer who builds the foundations for complex products — most recently leading design at Ownera, after high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1 and sweating the details."
- **Twitter + JSON-LD (shorter):** "A product designer who builds the foundations for complex products — most recently leading design at Ownera."
- `jobTitle` / image alt updated from "Senior Product Designer" to "Product Designer" to match the hero's wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_