### PR TITLE
Use the full hero text as the site description

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>
-  <meta name="description" content="I'm a product designer who builds the foundations for complex products — most recently leading design at Ownera, after high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1 and sweating the details.">
+  <meta name="description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://dekelhillel.com/">
@@ -16,7 +16,7 @@
   <meta property="og:url"         content="https://dekelhillel.com/">
   <meta property="og:site_name"   content="Dekel Hillel">
   <meta property="og:title"       content="Dekel Hillel">
-  <meta property="og:description" content="I'm a product designer who builds the foundations for complex products — most recently leading design at Ownera, after high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1 and sweating the details.">
+  <meta property="og:description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
   <meta property="og:image"       content="https://dekelhillel.com/og-image.png">
   <meta property="og:image:width"  content="1200">
   <meta property="og:image:height" content="630">
@@ -26,7 +26,7 @@
   <!-- ── Twitter / X Card ────────────────────────────────────── -->
   <meta name="twitter:card"        content="summary_large_image">
   <meta name="twitter:title"       content="Dekel Hillel">
-  <meta name="twitter:description" content="A product designer who builds the foundations for complex products — most recently leading design at Ownera.">
+  <meta name="twitter:description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
   <meta name="twitter:image"       content="https://dekelhillel.com/og-image.png">
   <meta name="twitter:image:alt"   content="Dekel Hillel, Product Designer">
 
@@ -46,7 +46,7 @@
     "name": "Dekel Hillel",
     "url": "https://dekelhillel.com",
     "jobTitle": "Product Designer",
-    "description": "A product designer who builds the foundations for complex products — most recently leading design at Ownera.",
+    "description": "I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.",
     "sameAs": [
       "https://www.linkedin.com/in/dekelhillel/"
     ],


### PR DESCRIPTION
## Summary
Per request, the meta description, OG description, Twitter description, and JSON-LD all now carry the hero copy verbatim, including the "helping teams be more ambitious" and Bezalel teaching lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_