### PR TITLE
Fix white flash on hard refresh with a hero preloading state

### DIFF
--- a/assets/hero-effects.js
+++ b/assets/hero-effects.js
@@ -477,6 +477,11 @@
   var bends = createColorBends();
   var dotField = createDotField();
 
+  var heroBg = hero.querySelector('.hero-bg');
+  var markReady = function () {
+    if (heroBg) heroBg.classList.add('fx-ready');
+  };
+
   var resizeTimer;
   window.addEventListener('resize', function () {
     clearTimeout(resizeTimer);
@@ -490,6 +495,7 @@
   function renderOnce() {
     if (bends) bends.render(0, 0);
     if (dotField) dotField.render();
+    markReady();
   }
 
   if (reduceMotion) {
@@ -508,6 +514,7 @@
     last = now;
     if (bends) bends.render(elapsed, dt);
     if (dotField) dotField.render();
+    markReady();  /* first frame is on screen — fade the layers in */
     rafId = requestAnimationFrame(loop);
   }
 

--- a/index.html
+++ b/index.html
@@ -190,6 +190,16 @@
       position: absolute;
       inset: 0;
       overflow: hidden;
+      /* Preloading state: layers stay hidden (showing the #110F18
+         background) until the first frame has rendered, preventing
+         the white-canvas flash on hard refresh */
+      opacity: 0;
+      transition: opacity 0.8s ease;
+    }
+
+    .hero-bg.fx-ready .hero-bends,
+    .hero-bg.fx-ready .hero-dots {
+      opacity: 1;
     }
 
     .hero-bends { z-index: 0; }


### PR DESCRIPTION
## Summary
On hard refresh the hero could flash white — the WebGL/canvas layers were visible before their first frame was drawn. The effect layers now start at `opacity: 0`, so the `#110F18` hero background is what shows while everything initializes, and they fade in over 0.8s once the first frame has actually rendered (also applies to the reduced-motion static frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_