### PR TITLE
Wire CV link to the uploaded PDF; remove Lite Platform link

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,7 +576,7 @@
         <span aria-hidden="true">•</span>
         <a href="https://www.linkedin.com/in/dekelhillel/" target="_blank" rel="noopener">LinkedIn</a>
         <span aria-hidden="true">•</span>
-        <a href="cv.pdf" target="_blank" rel="noopener">CV</a>
+        <a href="Dekel-Hillel-CV.pdf" target="_blank" rel="noopener">CV</a>
       </p>
     </div>
   </header>
@@ -640,7 +640,7 @@
           <img src="images/002-Placer.png" alt="Placer.ai Lite platform — Costco Wholesale overview with visit trend chart" loading="lazy" decoding="async" width="1920" height="1280">
         </picture>      </div>
 
-      <p class="notable" data-reveal><span class="label">Notable projects: </span><a href="placer-lite/">Lite Platform</a> • Design System &amp; React Transformation • Marketplace • Embedded Widgets</p>
+      <p class="notable" data-reveal><span class="label">Notable projects: </span>Lite Platform • Design System &amp; React Transformation • Marketplace • Embedded Widgets</p>
 
       <div class="space" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Summary
- The hero's **CV** link now opens `Dekel-Hillel-CV.pdf` (the file uploaded to the repo root) in a new tab
- **Lite Platform** in the Placer.ai notable projects line is plain text again (link to placer-lite/ removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_