### PR TITLE
Show the flow view image uncropped

### DIFF
--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -295,7 +295,7 @@
 
     .shot--json  { aspect-ratio: 2876 / 1626; }
     .shot--table { aspect-ratio: 1045 / 785; }
-    .shot--panel { aspect-ratio: 1046 / 730; border-radius: 24px; }
+    .shot--panel { aspect-ratio: 2880 / 2154; border-radius: 24px; }
 
     /* ── Labels ─────────────────────────────────────────────── */
     .label {


### PR DESCRIPTION
## Summary
The flow-view screenshot (`flow-rejected-hero`) was displayed at the design frame's 1046:730 crop, which trimmed the app's top bar and bottom zoom controls. The tile now uses the image's natural 2880:2154 aspect ratio, so the full screenshot shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_