### PR TITLE
Hide investor case-study image tiles until their exports exist

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -802,7 +802,10 @@
           reveal();
         } else {
           img.addEventListener('load', reveal);
-          /* keep the skeleton if an image is missing */
+          /* hide the tile entirely while its export is missing */
+          img.addEventListener('error', function () {
+            img.closest('.shot').style.display = 'none';
+          });
         }
       });
     })();


### PR DESCRIPTION
## Summary
The six body screenshots on `/ownera-investor/` aren't in the repo yet, and their tiles showed an endless loading shimmer. A failed image load now hides the tile entirely, so the page reads as complete text until the Figma exports are uploaded to `ownera-investor/assets/` (`portfolio-overview.png`, `assets-before.png`, `box-components.png`, `invest-flow.png`, `invest-mobile.png`, `production-states.png`). Once a file exists, its tile appears automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_