### PR TITLE
Create ownera-investor/assets folder for image uploads

### DIFF
--- a/ownera-investor/assets/README.txt
+++ b/ownera-investor/assets/README.txt
@@ -1,0 +1,7 @@
+Drop the six case-study exports here:
+portfolio-overview.png
+assets-before.png
+box-components.png
+invest-flow.png
+invest-mobile.png
+production-states.png


### PR DESCRIPTION
## Summary
Creates `ownera-investor/assets/` (with a README listing the six expected filenames) so the case-study image exports can be uploaded through the GitHub UI — uploading into a non-existent folder isn't possible there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_