### PR TITLE
Lightbox: focus ring only for keyboard users

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -511,6 +511,15 @@
       transform: scale(1.08);
     }
 
+    .lightbox-close:focus {
+      outline: none;  /* no ring on mouse/touch focus */
+    }
+
+    .lightbox-close:focus-visible {
+      outline: 2px solid rgba(255, 255, 255, 0.7);  /* keyboard only */
+      outline-offset: 2px;
+    }
+
     @media (prefers-reduced-motion: reduce) {
       .lightbox,
       .lightbox img,
@@ -903,7 +912,7 @@
         lightbox.classList.add('open');
         if (window.__lenis) window.__lenis.stop();
         document.addEventListener('keydown', onLightboxKey);
-        lightboxClose.focus();
+        lightboxClose.focus({ preventScroll: true });
       };
 
       lightbox.addEventListener('click', closeLightbox);

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -508,6 +508,15 @@
       transform: scale(1.08);
     }
 
+    .lightbox-close:focus {
+      outline: none;  /* no ring on mouse/touch focus */
+    }
+
+    .lightbox-close:focus-visible {
+      outline: 2px solid rgba(255, 255, 255, 0.7);  /* keyboard only */
+      outline-offset: 2px;
+    }
+
     @media (prefers-reduced-motion: reduce) {
       .lightbox,
       .lightbox img,
@@ -880,7 +889,7 @@
         lightbox.classList.add('open');
         if (window.__lenis) window.__lenis.stop();
         document.addEventListener('keydown', onLightboxKey);
-        lightboxClose.focus();
+        lightboxClose.focus({ preventScroll: true });
       };
 
       lightbox.addEventListener('click', closeLightbox);


### PR DESCRIPTION
## Summary
Opening the lightbox moves focus to the ✕ button (keyboard accessibility), which showed the browser's default blue focus ring even on mouse clicks. The button now suppresses the outline for pointer focus and shows a subtle white ring only under `:focus-visible` (keyboard navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_