### PR TITLE
Add reading progress bar to case-study pages

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -528,6 +528,23 @@
       }
     }
 
+
+    /* ============================================================
+       READING PROGRESS BAR
+    ============================================================ */
+    .progress-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 3px;
+      background: linear-gradient(90deg, #6366F1, #8b8ef7);
+      transform: scaleX(0);
+      transform-origin: 0 50%;
+      z-index: 50;
+      pointer-events: none;
+    }
+
     /* ============================================================
        BACK-TO-TOP BUTTON (same behavior as the homepage)
     ============================================================ */
@@ -656,6 +673,8 @@
   </style>
 </head>
 <body>
+
+  <div class="progress-bar" aria-hidden="true"></div>
 
   <div class="hero" aria-hidden="true">
     <div class="hero-bg">
@@ -835,10 +854,15 @@
   <script>
     (function () {
       var dot = document.querySelector('.back-dot');
+      var progressBar = document.querySelector('.progress-bar');
       var onScroll = function () {
         dot.classList.toggle('expanded', window.scrollY > 100);
+        var max = document.documentElement.scrollHeight - window.innerHeight;
+        var p = max > 0 ? Math.min(1, window.scrollY / max) : 0;
+        progressBar.style.transform = 'scaleX(' + p + ')';
       };
       window.addEventListener('scroll', onScroll, { passive: true });
+      window.addEventListener('resize', onScroll);
       onScroll();
 
       // Eased scroll-to-top: duration scales with distance, expo-out

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -525,6 +525,23 @@
       }
     }
 
+
+    /* ============================================================
+       READING PROGRESS BAR
+    ============================================================ */
+    .progress-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 3px;
+      background: linear-gradient(90deg, #6366F1, #8b8ef7);
+      transform: scaleX(0);
+      transform-origin: 0 50%;
+      z-index: 50;
+      pointer-events: none;
+    }
+
     /* ============================================================
        BACK-TO-TOP BUTTON (same behavior as the homepage)
     ============================================================ */
@@ -653,6 +670,8 @@
   </style>
 </head>
 <body>
+
+  <div class="progress-bar" aria-hidden="true"></div>
 
   <div class="hero" aria-hidden="true">
     <div class="hero-bg">
@@ -812,10 +831,15 @@
   <script>
     (function () {
       var dot = document.querySelector('.back-dot');
+      var progressBar = document.querySelector('.progress-bar');
       var onScroll = function () {
         dot.classList.toggle('expanded', window.scrollY > 100);
+        var max = document.documentElement.scrollHeight - window.innerHeight;
+        var p = max > 0 ? Math.min(1, window.scrollY / max) : 0;
+        progressBar.style.transform = 'scaleX(' + p + ')';
       };
       window.addEventListener('scroll', onScroll, { passive: true });
+      window.addEventListener('resize', onScroll);
       onScroll();
 
       // Eased scroll-to-top: duration scales with distance, expo-out


### PR DESCRIPTION
## Summary
Both internal case-study pages (`/transaction-log/`, `/ownera-investor/`) now show a 3px reading-progress bar fixed to the top of the viewport — an indigo gradient (matching the hero effect's #6366F1) that fills from left to right as you scroll. Driven by the pages' existing scroll handler (GPU-friendly `scaleX` transform), updates on resize, and is hidden from assistive tech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_