### PR TITLE
Lightbox: focus the dialog container, never draw a ring on open

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -910,6 +910,8 @@
       lightbox.setAttribute('role', 'dialog');
       lightbox.setAttribute('aria-modal', 'true');
       lightbox.setAttribute('aria-label', 'Image preview');
+      lightbox.setAttribute('tabindex', '-1');
+      lightbox.style.outline = 'none';
       var lightboxImg = document.createElement('img');
       lightboxImg.alt = '';
       var lightboxClose = document.createElement('button');
@@ -936,7 +938,7 @@
         lightbox.classList.add('open');
         if (window.__lenis) window.__lenis.stop();
         document.addEventListener('keydown', onLightboxKey);
-        lightboxClose.focus({ preventScroll: true });
+        lightbox.focus({ preventScroll: true });
       };
 
       lightbox.addEventListener('click', closeLightbox);

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -887,6 +887,8 @@
       lightbox.setAttribute('role', 'dialog');
       lightbox.setAttribute('aria-modal', 'true');
       lightbox.setAttribute('aria-label', 'Image preview');
+      lightbox.setAttribute('tabindex', '-1');
+      lightbox.style.outline = 'none';
       var lightboxImg = document.createElement('img');
       lightboxImg.alt = '';
       var lightboxClose = document.createElement('button');
@@ -913,7 +915,7 @@
         lightbox.classList.add('open');
         if (window.__lenis) window.__lenis.stop();
         document.addEventListener('keydown', onLightboxKey);
-        lightboxClose.focus({ preventScroll: true });
+        lightbox.focus({ preventScroll: true });
       };
 
       lightbox.addEventListener('click', closeLightbox);


### PR DESCRIPTION
## Summary
Follow-up to #60: programmatic focus on the ✕ button could still draw a focus ring in browsers whose heuristics treat script-driven focus as keyboard-like (notably Safari). Focus now lands on the `tabindex="-1"` dialog container (outline suppressed), which browsers never ring — while keyboard users can still Tab to the close button and get its `:focus-visible` ring, and Esc still closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_