### PR TITLE
Add horizontal divider between mobile stat rows

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -664,6 +664,11 @@
         padding-left: 32px;
       }
 
+      /* horizontal divider between the two rows */
+      .stat:nth-child(n+3) {
+        border-top: 1px solid var(--border);
+      }
+
       .dot-rail {
         --fab-size: 40px;
         --fab-dot:  20px;

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -661,6 +661,11 @@
         padding-left: 32px;
       }
 
+      /* horizontal divider between the two rows */
+      .stat:nth-child(n+3) {
+        border-top: 1px solid var(--border);
+      }
+
       .dot-rail {
         --fab-size: 40px;
         --fab-dot:  20px;


### PR DESCRIPTION
## Summary
On mobile the stats panel is a 2×2 grid that only had a vertical divider between the two columns. Both case-study pages now also get a horizontal divider between the top and bottom rows (a top border on the bottom-row cells), so the four stats read as a clean quadrant grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_