### PR TITLE
Use uploaded MP4 for the invest-flow animation instead of the GIF

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -271,7 +271,8 @@
       height: 100%;
     }
 
-    .shot img {
+    .shot img,
+    .shot video {
       display: block;
       width: 100%;
       height: 100%;
@@ -283,7 +284,8 @@
 
     .shot.loaded { background: none; }
     .shot.loaded::before { content: none; }
-    .shot.loaded img { opacity: 1; }
+    .shot.loaded img,
+    .shot.loaded video { opacity: 1; }
 
     @keyframes shimmer {
       100% { transform: translateX(100%); }
@@ -472,7 +474,8 @@
       pointer-events: auto;
     }
 
-    .lightbox img {
+    .lightbox img,
+    .lightbox video {
       max-width: min(1800px, 100%);
       max-height: 100%;
       width: auto;
@@ -483,9 +486,15 @@
       transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
     }
 
-    .lightbox.open img {
+    .lightbox.open img,
+    .lightbox.open video {
       transform: scale(1);
     }
+
+    /* only the active medium is shown */
+    .lightbox video { display: none; }
+    .lightbox.show-video img { display: none; }
+    .lightbox.show-video video { display: block; }
 
     .lightbox-close {
       position: absolute;
@@ -612,6 +621,7 @@
       .back-dot,
       .back-dot svg,
       .shot img,
+      .shot video,
       .back-link svg {
         transition: none;
       }
@@ -807,10 +817,10 @@
             <p>In the invest flow, I explored competing directions (A/B variants of the same steps) and landed on one principle: total cost transparency. Fees and FX exposed upfront, before commitment, and a deterministic review step before anything final. For users investing serious capital, trust isn't a brand value, it's a UI decision: they should never meet a number for the first time after clicking.</p>
           </div>
 
-          <div class="shot shot--invest shot--shadow" data-reveal>
-            <picture>
-              <img src="../images/Standardize-Modals.gif" alt="The invest flow — fees and FX exposed upfront with a deterministic review step" loading="lazy" decoding="async" width="1440" height="1024">
-            </picture>
+          <div class="shot shot--invest shot--shadow shot--video" data-reveal>
+            <video src="../images/Animation-Flow.mp4" width="1440" height="1024"
+                   autoplay loop muted playsinline preload="metadata"
+                   aria-label="The invest flow — fees and FX exposed upfront with a deterministic review step"></video>
           </div>
 
           <div class="shot shot--mobile shot--shadow" data-reveal>
@@ -924,16 +934,22 @@
       lightbox.style.outline = 'none';
       var lightboxImg = document.createElement('img');
       lightboxImg.alt = '';
+      var lightboxVideo = document.createElement('video');
+      lightboxVideo.setAttribute('controls', '');
+      lightboxVideo.setAttribute('loop', '');
+      lightboxVideo.setAttribute('playsinline', '');
       var lightboxClose = document.createElement('button');
       lightboxClose.className = 'lightbox-close';
-      lightboxClose.setAttribute('aria-label', 'Close image preview');
+      lightboxClose.setAttribute('aria-label', 'Close preview');
       lightboxClose.innerHTML = '&#10005;';
       lightbox.appendChild(lightboxImg);
+      lightbox.appendChild(lightboxVideo);
       lightbox.appendChild(lightboxClose);
       document.body.appendChild(lightbox);
 
       var closeLightbox = function () {
         lightbox.classList.remove('open');
+        lightboxVideo.pause();
         if (window.__lenis) window.__lenis.start();
         document.removeEventListener('keydown', onLightboxKey);
       };
@@ -942,25 +958,37 @@
         if (e.key === 'Escape') closeLightbox();
       };
 
-      var openLightbox = function (img) {
-        lightboxImg.src = img.getAttribute('src');  /* full-res PNG */
-        lightboxImg.alt = img.alt || '';
+      var openLightbox = function (media) {
+        var isVideo = media.tagName === 'VIDEO';
+        lightbox.classList.toggle('show-video', isVideo);
+        if (isVideo) {
+          lightboxVideo.src = media.getAttribute('src');
+          lightboxVideo.currentTime = 0;
+          lightboxVideo.play().catch(function () {});
+        } else {
+          lightboxImg.src = media.getAttribute('src');  /* full-res PNG */
+          lightboxImg.alt = media.alt || '';
+        }
         lightbox.classList.add('open');
         if (window.__lenis) window.__lenis.stop();
         document.addEventListener('keydown', onLightboxKey);
         lightbox.focus({ preventScroll: true });
       };
 
-      lightbox.addEventListener('click', closeLightbox);
+      lightbox.addEventListener('click', function (e) {
+        if (e.target !== lightboxVideo) closeLightbox();  /* keep video controls clickable */
+      });
 
       document.querySelectorAll('.shot').forEach(function (shot) {
         shot.addEventListener('click', function () {
+          var video = shot.querySelector('video');
+          if (video) { openLightbox(video); return; }
           var img = shot.querySelector('img');
           if (img && img.naturalWidth > 0) openLightbox(img);
         });
       });
 
-      // Reveal images once loaded; the .shot wrapper shows a
+      // Reveal media once loaded; the .shot wrapper shows a
       // shimmering skeleton until then.
       document.querySelectorAll('.shot img').forEach(function (img) {
         var reveal = function () { img.closest('.shot').classList.add('loaded'); };
@@ -971,6 +999,18 @@
           /* hide the tile entirely while its export is missing */
           img.addEventListener('error', function () {
             img.closest('.shot').style.display = 'none';
+          });
+        }
+      });
+
+      document.querySelectorAll('.shot video').forEach(function (video) {
+        var reveal = function () { video.closest('.shot').classList.add('loaded'); };
+        if (video.readyState >= 2) {
+          reveal();
+        } else {
+          video.addEventListener('loadeddata', reveal);
+          video.addEventListener('error', function () {
+            video.closest('.shot').style.display = 'none';
           });
         }
       });


### PR DESCRIPTION
## Summary
Replaces the `Standardize-Modals.gif` (4MB, 256-color, banded) in the invest-flow tile with the uploaded `images/Animation-Flow.mp4` (3MB, H.264), rendered as an autoplaying, looping, muted, inline `<video autoplay loop muted playsinline>` — smaller and much sharper than the GIF, and it plays silently just like the GIF did.

- Clicking the tile opens the video in the existing lightbox, now with playback controls (video-aware `openLightbox`; the ✕/backdrop still close it, video controls stay clickable).
- Added video-aware skeleton reveal (`loadeddata`) and reduced-motion handling next to the existing image code paths.
- The old GIF file is left in the repo but is no longer referenced anywhere.

Note: verified DOM wiring and layout in a headless render; H.264 playback itself can't be exercised in the test browser (Playwright's open-source Chromium has no proprietary H.264 decoder), but H.264 MP4 plays in all real browsers including iOS Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_