### PR TITLE
Reformat case-study page titles

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
-  <title>Designing for Investors Who Expect More, Dekel Hillel</title>
+  <title>Dekel Hillel · Designing for Investors Who Expect More</title>
   <meta name="description" content="Designing for Investors Who Expect More. Restructuring Ownera's investor app end-to-end: portfolio IA, focused asset views, transparent invest flow, and components that scale across data and bank brands.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="index, follow">

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
-  <title>From JSON Dump to Transaction Lifecycle, Dekel Hillel</title>
+  <title>Dekel Hillel · From JSON Dump to Transaction Lifecycle</title>
   <meta name="description" content="From JSON Dump to Transaction Lifecycle. Reframing Ownera's most-used admin screen from a raw JSON tree into a readable transaction lifecycle, so operations teams could diagnose failures without escalating.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="index, follow">


### PR DESCRIPTION
## Summary
Changes the `<title>` on both case-study pages to the `Dekel Hillel · <case study>` format:

- transaction-log: **Dekel Hillel · From JSON Dump to Transaction Lifecycle**
- ownera-investor: **Dekel Hillel · Designing for Investors Who Expect More**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_