### PR TITLE
Add eased hover tint on case-study images

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -293,6 +293,27 @@
       100% { transform: translateX(100%); }
     }
 
+    /* hover tint before opening the lightbox — #18141F at 10%,
+       eased in and out */
+    .shot::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: rgba(24, 20, 31, 0.1);
+      opacity: 0;
+      pointer-events: none;
+      z-index: 1;
+      transition: opacity 0.35s ease-in-out;
+    }
+
+    .shot:hover::after {
+      opacity: 1;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .shot::after { transition: none; }
+    }
+
     .shot--shadow {
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
     }

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -291,6 +291,27 @@
       100% { transform: translateX(100%); }
     }
 
+    /* hover tint before opening the lightbox — #18141F at 10%,
+       eased in and out */
+    .shot::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: rgba(24, 20, 31, 0.1);
+      opacity: 0;
+      pointer-events: none;
+      z-index: 1;
+      transition: opacity 0.35s ease-in-out;
+    }
+
+    .shot:hover::after {
+      opacity: 1;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .shot::after { transition: none; }
+    }
+
     .shot--shadow {
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
     }


### PR DESCRIPTION
## Summary
Hovering a screenshot on the case-study pages now fades in a subtle **10% `#18141F`** overlay (`rgba(24, 20, 31, 0.1)`) as an affordance before click-to-zoom.

- Implemented as a `.shot::after` layer, clipped to the tile's rounded corners and sitting above the image/video
- **Eased in and out** with `opacity 0.35s ease-in-out`
- `pointer-events: none` so it never blocks the click that opens the lightbox
- Static under `prefers-reduced-motion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_