### PR TITLE
Update /preview/ to hero reveal v2 (transparent, no resize gap)

### DIFF
--- a/js/hero-reveal.js
+++ b/js/hero-reveal.js
@@ -1,10 +1,10 @@
-/* Pinned hero → work reveal.
+/* Hero → work scroll reveal.
    On desktop (and only when the user hasn't asked for reduced motion),
-   the hero pins in place while the work section scrolls up and over it,
-   with the hero content easing back for depth — a restrained take on
-   GSAP's pinned-panels-with-overscroll pattern.
-   Integrates with the site's Lenis smooth scrolling and pauses cleanly
-   on mobile / reduced-motion, where normal scrolling is kept. */
+   the hero is fixed behind while the work section scrolls up over it,
+   with the hero content easing back and fading for depth.
+   Uses a scroll-scrubbed timeline (no GSAP pin), so there's no width
+   capture and no resize gaps. Mobile / reduced-motion keep normal
+   scrolling. Integrates with the site's Lenis smooth scrolling. */
 (function () {
   'use strict';
   if (!window.gsap || !window.ScrollTrigger) return;
@@ -24,31 +24,35 @@
     var heroBg = document.querySelector('.hero-bg');
     if (!hero || !heroInner) return;
 
+    /* Enables the fixed-hero CSS (see .reveal rules in the stylesheet). */
+    document.body.classList.add('reveal');
+
     var tl = gsap.timeline({
       scrollTrigger: {
-        trigger: hero,
-        start: 'top top',
-        end: 'bottom top',
-        pin: true,
-        pinSpacing: false,   /* let the work section scroll over the pinned hero */
-        scrub: 0.6,          /* slight catch-up for an overscroll-like feel */
+        trigger: document.documentElement,
+        start: 0,
+        end: function () { return window.innerHeight; },  /* recomputed on refresh/resize */
+        scrub: 0.6,
         invalidateOnRefresh: true
       }
     });
 
-    /* Hero content recedes as the work curtain rises. */
-    tl.to(heroInner, { yPercent: -14, opacity: 0, scale: 0.94, ease: 'power1.in' }, 0);
+    /* Hero content recedes as the work section rises over it. */
+    tl.to(heroInner, { yPercent: -14, scale: 0.94, ease: 'power1.in' }, 0)
+      /* Whole hero fades so the work sits on a clean background once covered. */
+      .to(hero, { opacity: 0, ease: 'power1.in' }, 0);
     /* Background drifts a touch for parallax depth. */
     if (heroBg) tl.to(heroBg, { scale: 1.06, ease: 'none' }, 0);
 
     /* matchMedia cleanup: fully revert when leaving the breakpoint. */
     return function () {
+      document.body.classList.remove('reveal');
       if (tl.scrollTrigger) tl.scrollTrigger.kill();
       tl.kill();
-      gsap.set([heroInner, heroBg], { clearProps: 'all' });
+      gsap.set([hero, heroInner, heroBg], { clearProps: 'all' });
     };
   });
 
-  /* Recompute pin distances once images and fonts have settled. */
+  /* Recompute distances once images and fonts have settled. */
   window.addEventListener('load', function () { ScrollTrigger.refresh(); });
 })();

--- a/preview/index.html
+++ b/preview/index.html
@@ -113,8 +113,6 @@
     .page {
       position: relative;
       z-index: 1;
-      /* opaque so it covers the pinned hero during the scroll reveal */
-      background: var(--bg);
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -185,6 +183,32 @@
       pointer-events: none;
       -webkit-mask-image: linear-gradient(to bottom, #000 72%, transparent 100%);
               mask-image: linear-gradient(to bottom, #000 72%, transparent 100%);
+    }
+
+    /* ============================================================
+       SCROLL REVEAL (desktop, motion-safe)
+       The hero is fixed behind while the work section scrolls up
+       over it — no GSAP pin, so no width capture / resize gaps.
+       js/hero-reveal.js adds .reveal to <body>.
+    ============================================================ */
+    @media (min-width: 1024px) and (prefers-reduced-motion: no-preference) {
+      body.reveal .hero {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 100vh;
+        min-height: 100vh;
+        z-index: 0;
+        will-change: opacity, transform;
+      }
+      /* page scrolls over the fixed hero; the first viewport is
+         reserved for the hero, and the background stays transparent
+         so the hero shows through the side gutters */
+      body.reveal .page {
+        margin-top: 100vh;
+        background: transparent;
+      }
     }
 
     .hero-bends,
@@ -671,7 +695,7 @@
 
   </div>
 
-  <div style="position:fixed;top:0;left:0;right:0;z-index:200;background:#6366F1;color:#fff;font:600 13px/34px system-ui,sans-serif;text-align:center;letter-spacing:.02em;pointer-events:none">PREVIEW · GSAP hero reveal — scroll down · your live homepage is unchanged</div>
+  <div style="position:fixed;top:0;left:0;right:0;z-index:200;background:#6366F1;color:#fff;font:600 13px/34px system-ui,sans-serif;text-align:center;letter-spacing:.02em;pointer-events:none">PREVIEW · GSAP hero reveal v2 — scroll down · your live homepage is unchanged</div>
   <div class="dot-rail">
     <button class="back-dot" aria-label="Back to top">
       <svg viewBox="0 0 29 29" fill="none" aria-hidden="true">


### PR DESCRIPTION
## Summary
Updates the `/preview/` demo to reveal **v2**, addressing both review points:
- **Transparent background** — the opaque `.page` band is gone; the hero shows through the side gutters during the reveal
- **No resize gap** — replaced GSAP's `pin` (which captured a stale width, causing the right-side dark gap on resize) with a fixed-hero + scroll-scrubbed timeline; the hero is full-width via CSS (`left:0/right:0`), so it can't desync on resize

Homepage still untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_