### PR TITLE
Update /preview/ to hero reveal v3 (natural-flow, robust)

### DIFF
--- a/js/hero-reveal.js
+++ b/js/hero-reveal.js
@@ -1,10 +1,10 @@
-/* Hero → work scroll reveal.
+/* Hero → work scroll reveal (natural flow).
    On desktop (and only when the user hasn't asked for reduced motion),
-   the hero is fixed behind while the work section scrolls up over it,
-   with the hero content easing back and fading for depth.
-   Uses a scroll-scrubbed timeline (no GSAP pin), so there's no width
-   capture and no resize gaps. Mobile / reduced-motion keep normal
-   scrolling. Integrates with the site's Lenis smooth scrolling. */
+   the hero scrolls away as usual while its content parallax-fades and
+   recedes for depth, and the work section rises up over the hero's
+   faded lower edge. No GSAP pin / fixed positioning / scroll-jacking,
+   so it reverses cleanly on scroll-up and never desyncs or leaves a
+   gap. Integrates with the site's Lenis smooth scrolling. */
 (function () {
   'use strict';
   if (!window.gsap || !window.ScrollTrigger) return;
@@ -24,35 +24,47 @@
     var heroBg = document.querySelector('.hero-bg');
     if (!hero || !heroInner) return;
 
-    /* Enables the fixed-hero CSS (see .reveal rules in the stylesheet). */
     document.body.classList.add('reveal');
 
-    var tl = gsap.timeline({
+    /* Hero content recedes and fades as the hero scrolls out of view. */
+    var innerTween = gsap.to(heroInner, {
+      yPercent: 26,
+      scale: 0.96,
+      opacity: 0,
+      ease: 'none',
       scrollTrigger: {
-        trigger: document.documentElement,
-        start: 0,
-        end: function () { return window.innerHeight; },  /* recomputed on refresh/resize */
+        trigger: hero,
+        start: 'center center',
+        end: 'bottom top',
         scrub: 0.6,
         invalidateOnRefresh: true
       }
     });
 
-    /* Hero content recedes as the work section rises over it. */
-    tl.to(heroInner, { yPercent: -14, scale: 0.94, ease: 'power1.in' }, 0)
-      /* Whole hero fades so the work sits on a clean background once covered. */
-      .to(hero, { opacity: 0, ease: 'power1.in' }, 0);
-    /* Background drifts a touch for parallax depth. */
-    if (heroBg) tl.to(heroBg, { scale: 1.06, ease: 'none' }, 0);
+    /* Background drifts a touch slower for parallax depth. */
+    var bgTween = heroBg ? gsap.to(heroBg, {
+      yPercent: 14,
+      ease: 'none',
+      scrollTrigger: {
+        trigger: hero,
+        start: 'top top',
+        end: 'bottom top',
+        scrub: 0.6,
+        invalidateOnRefresh: true
+      }
+    }) : null;
 
     /* matchMedia cleanup: fully revert when leaving the breakpoint. */
     return function () {
       document.body.classList.remove('reveal');
-      if (tl.scrollTrigger) tl.scrollTrigger.kill();
-      tl.kill();
-      gsap.set([hero, heroInner, heroBg], { clearProps: 'all' });
+      [innerTween, bgTween].forEach(function (t) {
+        if (!t) return;
+        if (t.scrollTrigger) t.scrollTrigger.kill();
+        t.kill();
+      });
+      gsap.set([heroInner, heroBg], { clearProps: 'all' });
     };
   });
 
-  /* Recompute distances once images and fonts have settled. */
   window.addEventListener('load', function () { ScrollTrigger.refresh(); });
 })();

--- a/preview/index.html
+++ b/preview/index.html
@@ -187,27 +187,23 @@
 
     /* ============================================================
        SCROLL REVEAL (desktop, motion-safe)
-       The hero is fixed behind while the work section scrolls up
-       over it — no GSAP pin, so no width capture / resize gaps.
-       js/hero-reveal.js adds .reveal to <body>.
+       Natural-flow reveal: the hero scrolls away as usual while its
+       content parallax-fades and recedes, and the work card rises
+       up over the hero's faded lower edge. No pin / fixed / scroll-
+       jacking, so it behaves correctly in both scroll directions and
+       at every width. js/hero-reveal.js adds .reveal to <body>.
     ============================================================ */
     @media (min-width: 1024px) and (prefers-reduced-motion: no-preference) {
-      body.reveal .hero {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 100vh;
-        min-height: 100vh;
-        z-index: 0;
-        will-change: opacity, transform;
-      }
-      /* page scrolls over the fixed hero; the first viewport is
-         reserved for the hero, and the background stays transparent
-         so the hero shows through the side gutters */
       body.reveal .page {
-        margin-top: 100vh;
-        background: transparent;
+        position: relative;
+        z-index: 1;
+        margin-top: -72px;   /* work rises into the hero's faded edge */
+      }
+      body.reveal .hero {
+        z-index: 0;
+      }
+      body.reveal .hero-inner {
+        will-change: opacity, transform;
       }
     }
 
@@ -695,7 +691,7 @@
 
   </div>
 
-  <div style="position:fixed;top:0;left:0;right:0;z-index:200;background:#6366F1;color:#fff;font:600 13px/34px system-ui,sans-serif;text-align:center;letter-spacing:.02em;pointer-events:none">PREVIEW · GSAP hero reveal v2 — scroll down · your live homepage is unchanged</div>
+  <div style="position:fixed;top:0;left:0;right:0;z-index:200;background:#6366F1;color:#fff;font:600 13px/34px system-ui,sans-serif;text-align:center;letter-spacing:.02em;pointer-events:none">PREVIEW · hero reveal v3 — scroll up &amp; down · homepage unchanged</div>
   <div class="dot-rail">
     <button class="back-dot" aria-label="Back to top">
       <svg viewBox="0 0 29 29" fill="none" aria-hidden="true">


### PR DESCRIPTION
## Summary
Updates `/preview/` to reveal **v3**. The fixed-hero + scroll-scrub approach could desync scroll position from the fade (blank state on scroll-up). Replaced with a natural-flow parallax reveal: the hero scrolls away normally while its content fades and recedes, and the work rises into the hero's faded edge. No pin / fixed / margin-100vh — the work is always in flow (never blank), reverses cleanly on scroll-up, and can't gap on resize.

Homepage still untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_