### PR TITLE
Add llms.txt with auto-regeneration workflow

### DIFF
--- a/.github/workflows/update-llms.yml
+++ b/.github/workflows/update-llms.yml
@@ -1,0 +1,32 @@
+name: Update llms.txt
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.html"
+      - "scripts/generate-llms.py"
+
+permissions:
+  contents: write
+
+jobs:
+  update-llms:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Regenerate llms.txt
+        run: python3 scripts/generate-llms.py
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet llms.txt; then
+            echo "llms.txt already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add llms.txt
+          git commit -m "chore: regenerate llms.txt from site content"
+          git push

--- a/llms.txt
+++ b/llms.txt
@@ -1,20 +1,20 @@
 # Dekel Hillel
 
-> Senior Product Designer focused on architecting complex B2B infrastructure from the ground up. Expert at translating high-scale data platforms into intuitive tools, with experience leading design at Ownera, Placer.ai, and SimilarWeb. Based portfolio: https://dekelhillel.com
+> A Senior Product Designer focused on architecting complex B2B infrastructure from the ground up. An expert at translating high-scale data platforms into intuitive tools, with proven experience leading design at Ownera, Placer.ai, and SimilarWeb. Portfolio: https://dekelhillel.com
 
-Dekel builds the foundations for complex products — taking things from 0 to 1, designing systems, and helping teams ship ambitious work. Most recently led design at Ownera (fintech infrastructure for trading tokenized assets between financial institutions, backed by J.P. Morgan). Previously did high-scale work at SimilarWeb and Placer.ai, and taught a UX/UI course at Bezalel Academy of Arts and Design.
+I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.
 
 ## Case Studies
 
-- [From JSON Dump to Transaction Lifecycle](https://dekelhillel.com/transaction-log/): Ownera admin platform — giving operations teams a way to diagnose transaction failures themselves, instead of escalating raw JSON to engineering.
-- [Designing for Investors Who Expect More](https://dekelhillel.com/ownera-investor/): The full investor experience on an institutional digital-asset platform — portfolio, invest flow, trading, and account management.
-- [Placer.ai Lite Platform](https://dekelhillel.com/placer-lite/): Free access to a paid location-intelligence platform, without giving the platform away — a public product that converts unfamiliar visitors into paying users.
+- [From JSON Dump to Transaction Lifecycle](https://dekelhillel.com/transaction-log/): Giving operations teams a way to diagnose failures themselves, instead of escalating raw JSON to engineering.
+- [Designing for Investors Who Expect More](https://dekelhillel.com/ownera-investor/): The full investor experience on an institutional digital-asset platform: portfolio, invest flow, trading, and account management.
+- [Free Access to a Paid Data Platform, Without Giving the Platform Away](https://dekelhillel.com/placer-lite/): A free, public product that converts unfamiliar visitors into paying users.
 
 ## Experience
 
-- Ownera (2023–2026): Led design. 40+ shipped features across the Admin and Investor platforms, on a design system built from scratch.
-- Placer.ai (2021–2022): Location intelligence unicorn. Notable projects: Lite Platform, Design System & React Transformation, Marketplace, Embedded Widgets.
-- SimilarWeb (2018–2020): Digital intelligence platform. Notable projects: Extension Redesign, Registration Funnel & Onboarding, Cross-Platform B2C Products.
+- Ownera (2023 → 2026): Ownera is Fintech infrastructure for trading tokenized assets between financial institutions, backed by J.P. Morgan. Beyond the two case studies: 40+ shipped features across the Admin and Investor platforms, on a design system I built from scratch.
+- Placer.ai (2021 → 2022): Placer.ai is a location intelligence unicorn: foot-traffic analytics for retail, real estate, and finance. Notable projects: Lite Platform • Design System & React Transformation • Marketplace • Embedded Widgets
+- SimilarWeb (2018 → 2020): SimilarWeb is a digital intelligence platform that helps businesses understand market trends and competitive landscapes. Notable projects: SimilarWeb Extension Redesign • Registration Funnel & Onboarding • Cross-Platform B2C Products
 
 ## Contact
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# Dekel Hillel
+
+> Senior Product Designer focused on architecting complex B2B infrastructure from the ground up. Expert at translating high-scale data platforms into intuitive tools, with experience leading design at Ownera, Placer.ai, and SimilarWeb. Based portfolio: https://dekelhillel.com
+
+Dekel builds the foundations for complex products — taking things from 0 to 1, designing systems, and helping teams ship ambitious work. Most recently led design at Ownera (fintech infrastructure for trading tokenized assets between financial institutions, backed by J.P. Morgan). Previously did high-scale work at SimilarWeb and Placer.ai, and taught a UX/UI course at Bezalel Academy of Arts and Design.
+
+## Case Studies
+
+- [From JSON Dump to Transaction Lifecycle](https://dekelhillel.com/transaction-log/): Ownera admin platform — giving operations teams a way to diagnose transaction failures themselves, instead of escalating raw JSON to engineering.
+- [Designing for Investors Who Expect More](https://dekelhillel.com/ownera-investor/): The full investor experience on an institutional digital-asset platform — portfolio, invest flow, trading, and account management.
+- [Placer.ai Lite Platform](https://dekelhillel.com/placer-lite/): Free access to a paid location-intelligence platform, without giving the platform away — a public product that converts unfamiliar visitors into paying users.
+
+## Experience
+
+- Ownera (2023–2026): Led design. 40+ shipped features across the Admin and Investor platforms, on a design system built from scratch.
+- Placer.ai (2021–2022): Location intelligence unicorn. Notable projects: Lite Platform, Design System & React Transformation, Marketplace, Embedded Widgets.
+- SimilarWeb (2018–2020): Digital intelligence platform. Notable projects: Extension Redesign, Registration Funnel & Onboarding, Cross-Platform B2C Products.
+
+## Contact
+
+- [Email](mailto:h.dekel@gmail.com)
+- [LinkedIn](https://www.linkedin.com/in/dekelhillel/)
+- [CV](https://dekelhillel.com/cv.pdf)

--- a/llms.txt
+++ b/llms.txt
@@ -1,13 +1,11 @@
 # Dekel Hillel
 
-> A Senior Product Designer focused on architecting complex B2B infrastructure from the ground up. An expert at translating high-scale data platforms into intuitive tools, with proven experience leading design at Ownera, Placer.ai, and SimilarWeb. Portfolio: https://dekelhillel.com
-
-I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.
+> I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design. Portfolio: https://dekelhillel.com
 
 ## Case Studies
 
-- [From JSON Dump to Transaction Lifecycle](https://dekelhillel.com/transaction-log/): Giving operations teams a way to diagnose failures themselves, instead of escalating raw JSON to engineering.
-- [Designing for Investors Who Expect More](https://dekelhillel.com/ownera-investor/): The full investor experience on an institutional digital-asset platform: portfolio, invest flow, trading, and account management.
+- [From JSON Dump to Transaction Lifecycle](https://dekelhillel.com/transaction-log/): Reframing Ownera's most-used admin screen from a raw JSON tree into a readable transaction lifecycle, so operations teams could diagnose failures without escalating.
+- [Designing for Investors Who Expect More](https://dekelhillel.com/ownera-investor/): Restructuring Ownera's investor app end-to-end: portfolio IA, focused asset views, transparent invest flow, and components that scale across data and bank brands.
 - [Free Access to a Paid Data Platform, Without Giving the Platform Away](https://dekelhillel.com/placer-lite/): A free, public product that converts unfamiliar visitors into paying users.
 
 ## Experience

--- a/scripts/generate-llms.py
+++ b/scripts/generate-llms.py
@@ -57,6 +57,9 @@ def main():
     # Keep the intro's sentence flow: paragraph breaks become one line each.
     intro_lines = [collapse(l) for l in strip_tags(intro_html).split("\n")]
     bio = " ".join(l for l in intro_lines if l)
+    # When the meta description just mirrors the intro, one copy is enough.
+    if collapse(summary) == bio:
+        bio = ""
 
     # Case studies: title from each page's <h1>, blurb from its meta description.
     cases = []
@@ -99,12 +102,11 @@ def main():
     )
     experience_lines = "\n".join(experience)
 
+    bio_block = f"\n{bio}\n" if bio else ""
     out = f"""# Dekel Hillel
 
 > {summary} Portfolio: {BASE_URL}
-
-{bio}
-
+{bio_block}
 ## Case Studies
 
 {case_lines}

--- a/scripts/generate-llms.py
+++ b/scripts/generate-llms.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Regenerate llms.txt from the site's HTML.
+
+Sources of truth:
+- index.html: meta description (summary), hero intro (bio),
+  company sections (experience), notable-projects lines.
+- Each case-study page: <h1> (title) and meta description.
+
+Run from the repo root: python3 scripts/generate-llms.py
+The GitHub Action in .github/workflows/update-llms.yml runs this on
+every push to main and commits the result when it changed.
+"""
+import html
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BASE_URL = "https://dekelhillel.com"
+CASE_DIRS = ["transaction-log", "ownera-investor", "placer-lite"]
+
+
+def read(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def strip_tags(fragment):
+    text = re.sub(r"<br\s*/?>", "\n", fragment)
+    text = re.sub(r"<[^>]+>", "", text)
+    return html.unescape(text)
+
+
+def collapse(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def meta_description(doc):
+    m = re.search(r'name="description"\s+content="([^"]*)"', doc)
+    return html.unescape(m.group(1)) if m else ""
+
+
+def first_match(pattern, doc, label):
+    m = re.search(pattern, doc, re.S)
+    if not m:
+        sys.exit(f"generate-llms: could not find {label}")
+    return m.group(1)
+
+
+def main():
+    index = read("index.html")
+
+    summary = meta_description(index)
+
+    intro_html = first_match(
+        r'<p class="intro"[^>]*>(.*?)</p>', index, "hero intro in index.html"
+    )
+    # Keep the intro's sentence flow: paragraph breaks become one line each.
+    intro_lines = [collapse(l) for l in strip_tags(intro_html).split("\n")]
+    bio = " ".join(l for l in intro_lines if l)
+
+    # Case studies: title from each page's <h1>, blurb from its meta description.
+    cases = []
+    for d in CASE_DIRS:
+        doc = read(f"{d}/index.html")
+        title = collapse(strip_tags(first_match(
+            r"<h1[^>]*>(.*?)</h1>", doc, f"<h1> in {d}/index.html"
+        )))
+        blurb = meta_description(doc)
+        # Meta descriptions open with the page title — drop the repeat.
+        if blurb.startswith(title):
+            blurb = blurb[len(title):].lstrip(" .")
+        cases.append((title, f"{BASE_URL}/{d}/", blurb))
+
+    # Experience: each .company section, plus the nearest following
+    # note/notable paragraph (searched within the section's tail).
+    experience = []
+    sections = re.findall(
+        r'<section class="company"[^>]*>\s*<h2>(.*?)</h2>\s*'
+        r'<p class="dates">(.*?)</p>\s*<p>(.*?)</p>\s*</section>(.*?)'
+        r'(?=<section class="company"|</main>)',
+        index,
+        re.S,
+    )
+    if not sections:
+        sys.exit("generate-llms: could not find company sections in index.html")
+    for name, dates, blurb, tail in sections:
+        detail = ""
+        note = re.search(r'<p class="(?:note|notable)"[^>]*>(.*?)</p>', tail, re.S)
+        if note:
+            detail = collapse(strip_tags(note.group(1)))
+            detail = re.sub(r"^Notable projects:\s*", "Notable projects: ", detail)
+        entry = f"- {collapse(strip_tags(name))} ({collapse(strip_tags(dates))}): {collapse(strip_tags(blurb))}"
+        if detail:
+            entry += f" {detail}"
+        experience.append(entry)
+
+    case_lines = "\n".join(
+        f"- [{title}]({url}): {blurb}" for title, url, blurb in cases
+    )
+    experience_lines = "\n".join(experience)
+
+    out = f"""# Dekel Hillel
+
+> {summary} Portfolio: {BASE_URL}
+
+{bio}
+
+## Case Studies
+
+{case_lines}
+
+## Experience
+
+{experience_lines}
+
+## Contact
+
+- [Email](mailto:h.dekel@gmail.com)
+- [LinkedIn](https://www.linkedin.com/in/dekelhillel/)
+- [CV]({BASE_URL}/cv.pdf)
+"""
+
+    target = ROOT / "llms.txt"
+    if target.exists() and target.read_text(encoding="utf-8") == out:
+        print("llms.txt is up to date")
+    else:
+        target.write_text(out, encoding="utf-8")
+        print("llms.txt regenerated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds `llms.txt` for AI crawler/agent discoverability, plus a generator script and GitHub Action that keep it in sync with the site content automatically.

These commits were part of the branch behind #42 but were not included in that merge — the merge picked up an earlier head of the branch. This PR re-applies them on top of current `main`, with the content regenerated against the latest HTML (updated case-study descriptions, deduped bio).

## Key Changes
- **`llms.txt`**: canonical machine-readable summary of the portfolio — bio, case studies with links and blurbs, experience, contact.
- **`scripts/generate-llms.py`**: stdlib-only Python script that rebuilds `llms.txt` from the HTML sources of truth (homepage meta/intro/company sections, each case study's h1 + meta description). Idempotent.
- **`.github/workflows/update-llms.yml`**: on every push to `main` touching HTML, regenerates `llms.txt` and commits it if the content changed. Requires the repo's workflow permissions set to Read and write (already done).

## Testing
Ran the generator against current `main` content; verified output and idempotence (second run reports "up to date").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eNfXsHRG3eowdk6CV5pwB

---
_Generated by [Claude Code](https://claude.ai/code/session_017eNfXsHRG3eowdk6CV5pwB)_