### PR TITLE
Add sticky Back bar to case-study pages

### DIFF
--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -405,24 +405,30 @@
       width: 100%;
       z-index: 40;  /* below the reading progress bar (50) */
       background: rgba(24, 20, 31, 0.7);
-      -webkit-backdrop-filter: blur(14px);
-              backdrop-filter: blur(14px);
-      transform: translateY(-100%);
       opacity: 0;
       visibility: hidden;
+      transform: translateY(-8px);
       transition:
-        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
-        opacity 0.3s ease,
-        visibility 0s linear 0.4s;
+        opacity 0.5s ease,
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        -webkit-backdrop-filter 0.5s ease,
+        backdrop-filter 0.5s ease,
+        visibility 0s linear 0.5s;
+      -webkit-backdrop-filter: blur(0px);
+              backdrop-filter: blur(0px);
     }
 
     .back-bar.visible {
-      transform: translateY(0);
       opacity: 1;
       visibility: visible;
+      transform: translateY(0);
+      -webkit-backdrop-filter: blur(14px);
+              backdrop-filter: blur(14px);
       transition:
-        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
-        opacity 0.3s ease;
+        opacity 0.5s ease,
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        -webkit-backdrop-filter 0.5s ease,
+        backdrop-filter 0.5s ease;
     }
 
     .back-bar-inner {

--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -392,6 +392,46 @@
       transform: translateX(-4px);
     }
 
+    /* ============================================================
+       STICKY BACK BAR
+       Slides in from the top once the inline Back link scrolls out
+       of view; the inner wrapper mirrors the content column so the
+       link stays aligned with the page at every breakpoint.
+    ============================================================ */
+    .back-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      z-index: 40;  /* below the reading progress bar (50) */
+      background: rgba(24, 20, 31, 0.7);
+      -webkit-backdrop-filter: blur(14px);
+              backdrop-filter: blur(14px);
+      transform: translateY(-100%);
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+        opacity 0.3s ease,
+        visibility 0s linear 0.4s;
+    }
+
+    .back-bar.visible {
+      transform: translateY(0);
+      opacity: 1;
+      visibility: visible;
+      transition:
+        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+        opacity 0.3s ease;
+    }
+
+    .back-bar-inner {
+      max-width: calc(1045px + 80px);  /* content column + page gutters */
+      margin: 0 auto;
+      padding: 24px 40px;
+      display: flex;
+    }
+
     .crumb-title {
       display: flex;
       flex-direction: column;
@@ -822,6 +862,10 @@
         transition: none;
       }
 
+      .back-bar {
+        transition: none;
+      }
+
       .shot::before {
         animation: none;
       }
@@ -846,6 +890,10 @@
     @media (max-width: 700px) {
       body {
         font-size: 1rem;  /* 16px */
+      }
+
+      .back-bar-inner {
+        padding: 16px 40px;
       }
 
       .page {
@@ -886,6 +934,17 @@
 <body>
 
   <div class="progress-bar" aria-hidden="true"></div>
+
+  <div class="back-bar">
+    <div class="back-bar-inner">
+      <a class="back-link" href="../">
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M19 12H5M5 12L12 19M5 12L12 5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>Back</span>
+      </a>
+    </div>
+  </div>
 
   <div class="hero" aria-hidden="true">
     <div class="hero-bg">
@@ -1071,8 +1130,11 @@
     (function () {
       var dot = document.querySelector('.back-dot');
       var progressBar = document.querySelector('.progress-bar');
+      var backBar = document.querySelector('.back-bar');
+      var inlineBack = document.querySelector('.case-header .back-link');
       var onScroll = function () {
         dot.classList.toggle('expanded', window.scrollY > 100);
+        backBar.classList.toggle('visible', inlineBack.getBoundingClientRect().bottom < 0);
         var max = document.documentElement.scrollHeight - window.innerHeight;
         var p = max > 0 ? Math.min(1, window.scrollY / max) : 0;
         progressBar.style.transform = 'scaleX(' + p + ')';

--- a/placer-lite/index.html
+++ b/placer-lite/index.html
@@ -78,13 +78,17 @@
   .back-bar{
     position:fixed; top:0; left:0; width:100%; z-index:150;
     background:rgba(29,29,31,0.7);
-    -webkit-backdrop-filter:blur(14px); backdrop-filter:blur(14px);
-    transform:translateY(-100%); opacity:0; visibility:hidden;
-    transition:transform .4s var(--ease), opacity .3s ease, visibility 0s linear .4s;
+    opacity:0; visibility:hidden; transform:translateY(-8px);
+    -webkit-backdrop-filter:blur(0px); backdrop-filter:blur(0px);
+    transition:opacity .5s ease, transform .6s var(--ease),
+      -webkit-backdrop-filter .5s ease, backdrop-filter .5s ease,
+      visibility 0s linear .5s;
   }
   .back-bar.visible{
-    transform:translateY(0); opacity:1; visibility:visible;
-    transition:transform .4s var(--ease), opacity .3s ease;
+    opacity:1; visibility:visible; transform:translateY(0);
+    -webkit-backdrop-filter:blur(14px); backdrop-filter:blur(14px);
+    transition:opacity .5s ease, transform .6s var(--ease),
+      -webkit-backdrop-filter .5s ease, backdrop-filter .5s ease;
   }
   .back-bar-inner{ max-width:1160px; margin:0 auto; padding:20px 40px; display:flex; }
   .menu-spacer{ flex:1; }

--- a/placer-lite/index.html
+++ b/placer-lite/index.html
@@ -73,6 +73,20 @@
   .menu-back .back-arrow{ display:inline-block; transition:transform .25s var(--ease); }
   a.menu-back:hover{ opacity:1; color:var(--text); }
   a.menu-back:hover .back-arrow{ transform:translateX(-4px); }
+
+  /* ---------- sticky back bar (appears after the header scrolls away) ---------- */
+  .back-bar{
+    position:fixed; top:0; left:0; width:100%; z-index:150;
+    background:rgba(29,29,31,0.7);
+    -webkit-backdrop-filter:blur(14px); backdrop-filter:blur(14px);
+    transform:translateY(-100%); opacity:0; visibility:hidden;
+    transition:transform .4s var(--ease), opacity .3s ease, visibility 0s linear .4s;
+  }
+  .back-bar.visible{
+    transform:translateY(0); opacity:1; visibility:visible;
+    transition:transform .4s var(--ease), opacity .3s ease;
+  }
+  .back-bar-inner{ max-width:1160px; margin:0 auto; padding:20px 40px; display:flex; }
   .menu-spacer{ flex:1; }
   .menu-meta{
     font-family:var(--font-body); font-size:13px; color:var(--secondary);
@@ -286,6 +300,7 @@
   @media (max-width:1316px){
     .heading,.subhead,.tags{ animation:none; opacity:1; transform:none; }
     .menu{ padding:20px 24px; gap:16px; }
+    .back-bar-inner{ padding:16px 24px; }
     .main{ padding:8px 24px 40px; }
     .back-to-top{ bottom:24px; right:24px; }
   }
@@ -293,6 +308,7 @@
   /* ---------- mobile ≤799px ---------- */
   @media (max-width:799px){
     .menu{ flex-wrap:wrap; gap:12px; padding:18px 20px; }
+    .back-bar-inner{ padding:14px 20px; }
     .menu-meta{ display:none; }
     .heading{ font-size:42px; letter-spacing:-2px; }
     .sec-head{ font-size:28px; letter-spacing:-1px; }
@@ -316,6 +332,12 @@
 
 <!-- Background gradient glow -->
 <div class="bg-glow" aria-hidden="true"></div>
+
+<div class="back-bar">
+  <div class="back-bar-inner">
+    <a href="../" class="menu-link menu-back"><span class="back-arrow" aria-hidden="true">&#8592;</span> Back</a>
+  </div>
+</div>
 
 <div class="layout">
 
@@ -488,7 +510,12 @@
 
   // back to top
   const toTop=document.getElementById('toTop');
-  window.addEventListener('scroll',()=>{ toTop.classList.toggle('visible', window.scrollY>600); });
+  const backBar=document.querySelector('.back-bar');
+  const menuBack=document.querySelector('.menu .menu-back');
+  window.addEventListener('scroll',()=>{
+    toTop.classList.toggle('visible', window.scrollY>600);
+    backBar.classList.toggle('visible', menuBack.getBoundingClientRect().bottom<0);
+  });
   toTop.addEventListener('click',()=>window.__lenis ? window.__lenis.scrollTo(0) : window.scrollTo({top:0,behavior:'smooth'}));
 </script>
 <!-- Lenis smooth scrolling (shared) -->

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -405,24 +405,30 @@
       width: 100%;
       z-index: 40;  /* below the reading progress bar (50) */
       background: rgba(24, 20, 31, 0.7);
-      -webkit-backdrop-filter: blur(14px);
-              backdrop-filter: blur(14px);
-      transform: translateY(-100%);
       opacity: 0;
       visibility: hidden;
+      transform: translateY(-8px);
       transition:
-        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
-        opacity 0.3s ease,
-        visibility 0s linear 0.4s;
+        opacity 0.5s ease,
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        -webkit-backdrop-filter 0.5s ease,
+        backdrop-filter 0.5s ease,
+        visibility 0s linear 0.5s;
+      -webkit-backdrop-filter: blur(0px);
+              backdrop-filter: blur(0px);
     }
 
     .back-bar.visible {
-      transform: translateY(0);
       opacity: 1;
       visibility: visible;
+      transform: translateY(0);
+      -webkit-backdrop-filter: blur(14px);
+              backdrop-filter: blur(14px);
       transition:
-        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
-        opacity 0.3s ease;
+        opacity 0.5s ease,
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        -webkit-backdrop-filter 0.5s ease,
+        backdrop-filter 0.5s ease;
     }
 
     .back-bar-inner {

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -392,6 +392,46 @@
       transform: translateX(-4px);
     }
 
+    /* ============================================================
+       STICKY BACK BAR
+       Slides in from the top once the inline Back link scrolls out
+       of view; the inner wrapper mirrors the content column so the
+       link stays aligned with the page at every breakpoint.
+    ============================================================ */
+    .back-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      z-index: 40;  /* below the reading progress bar (50) */
+      background: rgba(24, 20, 31, 0.7);
+      -webkit-backdrop-filter: blur(14px);
+              backdrop-filter: blur(14px);
+      transform: translateY(-100%);
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+        opacity 0.3s ease,
+        visibility 0s linear 0.4s;
+    }
+
+    .back-bar.visible {
+      transform: translateY(0);
+      opacity: 1;
+      visibility: visible;
+      transition:
+        transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+        opacity 0.3s ease;
+    }
+
+    .back-bar-inner {
+      max-width: calc(1045px + 80px);  /* content column + page gutters */
+      margin: 0 auto;
+      padding: 24px 40px;
+      display: flex;
+    }
+
     .crumb-title {
       display: flex;
       flex-direction: column;
@@ -809,6 +849,10 @@
         transition: none;
       }
 
+      .back-bar {
+        transition: none;
+      }
+
       .shot::before {
         animation: none;
       }
@@ -833,6 +877,10 @@
     @media (max-width: 700px) {
       body {
         font-size: 1rem;  /* 16px */
+      }
+
+      .back-bar-inner {
+        padding: 16px 40px;
       }
 
       .page {
@@ -873,6 +921,17 @@
 <body>
 
   <div class="progress-bar" aria-hidden="true"></div>
+
+  <div class="back-bar">
+    <div class="back-bar-inner">
+      <a class="back-link" href="../">
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M19 12H5M5 12L12 19M5 12L12 5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>Back</span>
+      </a>
+    </div>
+  </div>
 
   <div class="hero" aria-hidden="true">
     <div class="hero-bg">
@@ -1033,8 +1092,11 @@
     (function () {
       var dot = document.querySelector('.back-dot');
       var progressBar = document.querySelector('.progress-bar');
+      var backBar = document.querySelector('.back-bar');
+      var inlineBack = document.querySelector('.case-header .back-link');
       var onScroll = function () {
         dot.classList.toggle('expanded', window.scrollY > 100);
+        backBar.classList.toggle('visible', inlineBack.getBoundingClientRect().bottom < 0);
         var max = document.documentElement.scrollHeight - window.innerHeight;
         var p = max > 0 ? Math.min(1, window.scrollY / max) : 0;
         progressBar.style.transform = 'scaleX(' + p + ')';


### PR DESCRIPTION
## Summary
Implements the sticky Back bar from the Figma spec (node 772-420) on all three case-study pages: once the inline Back link scrolls out of view, a fixed top bar with the Back link slides in; it slides away when returning to the top.

## Key Changes
- **Design**: full-width bar, translucent page-tinted background (`rgba(24,20,31,0.7)` on the dark pages, `rgba(29,29,31,0.7)` on placer-lite) with 14px backdrop blur, arrow + "Back" at 18px — matching the Figma frame.
- **Alignment across breakpoints**: the bar's inner wrapper mirrors each page's content column — 1045px column + 40px gutters on transaction-log/ownera-investor (link lands at 197.5px on a 1440px viewport, exactly as in Figma), 1160px column on placer-lite with its 1316px/799px gutter steps; slimmer vertical padding on mobile.
- **Behavior**: visibility toggles off the inline Back link's actual position (not a magic scroll number), wired into each page's existing scroll handler. Sits below the reading progress bar; hidden state uses `visibility: hidden` so the duplicate link never traps keyboard focus; slide/fade transition disabled under `prefers-reduced-motion`.

## Testing
Verified in headless Chromium on all three pages at 1440px, 1024px, and 390px: bar hidden at top, appears after scrolling past the inline link, pixel-aligned with the content column, hides again on return to top, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eNfXsHRG3eowdk6CV5pwB

---
_Generated by [Claude Code](https://claude.ai/code/session_017eNfXsHRG3eowdk6CV5pwB)_