### PR TITLE
Add Google Analytics (GA4) to all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BXLP0J2923"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BXLP0J2923');
+  </script>
+
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>
   <meta name="description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">

--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BXLP0J2923"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BXLP0J2923');
+  </script>
+
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel · Designing for Investors Who Expect More</title>
   <meta name="description" content="Designing for Investors Who Expect More. Restructuring Ownera's investor app end-to-end: portfolio IA, focused asset views, transparent invest flow, and components that scale across data and bank brands.">

--- a/placer-lite/index.html
+++ b/placer-lite/index.html
@@ -3,6 +3,16 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BXLP0J2923"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BXLP0J2923');
+  </script>
 <title>Placer.ai Free Product, Dekel Hillel</title>
 <meta name="description" content="Free Access to a Paid Data Platform, Without Giving the Platform Away. A free, public product that converts unfamiliar visitors into paying users.">
 <link rel="icon" href="../favicon.svg" type="image/svg+xml">

--- a/preview/index.html
+++ b/preview/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BXLP0J2923"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BXLP0J2923');
+  </script>
+
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>
   <meta name="description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">

--- a/transaction-log.html
+++ b/transaction-log.html
@@ -3,6 +3,16 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BXLP0J2923"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BXLP0J2923');
+  </script>
 <title>Transaction Log — Dekel Hillel</title>
 <meta name="description" content="From JSON Dump to Transaction Lifecycle. Giving operations teams a way to diagnose failures themselves, instead of escalating raw JSON to engineering.">
 <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BXLP0J2923"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BXLP0J2923');
+  </script>
+
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel · From JSON Dump to Transaction Lifecycle</title>
   <meta name="description" content="From JSON Dump to Transaction Lifecycle. Reframing Ownera's most-used admin screen from a raw JSON tree into a readable transaction lifecycle, so operations teams could diagnose failures without escalating.">


### PR DESCRIPTION
Adds the Google Analytics 4 tag (measurement ID `G-BXLP0J2923`) to every page, placed immediately after the opening `<head>` (right after the charset/viewport meta so document encoding is still resolved first). Exactly one tag per page — no duplicates.

Pages covered:
- `index.html`
- `transaction-log/index.html`
- `ownera-investor/index.html`
- `placer-lite/index.html`
- `transaction-log.html` (stale orphan page, unlinked but publicly reachable)
- `preview/index.html` (staging mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_