### PR TITLE
Add Hotjar tracking to all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,17 @@
 
     gtag('config', 'G-BXLP0J2923');
   </script>
+  <!-- Hotjar Tracking Code for www.dekelhillel.com -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2517369,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>

--- a/ownera-investor/index.html
+++ b/ownera-investor/index.html
@@ -13,6 +13,17 @@
 
     gtag('config', 'G-BXLP0J2923');
   </script>
+  <!-- Hotjar Tracking Code for www.dekelhillel.com -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2517369,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel · Designing for Investors Who Expect More</title>

--- a/placer-lite/index.html
+++ b/placer-lite/index.html
@@ -13,6 +13,17 @@
 
     gtag('config', 'G-BXLP0J2923');
   </script>
+  <!-- Hotjar Tracking Code for www.dekelhillel.com -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2517369,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
 <title>Placer.ai Free Product, Dekel Hillel</title>
 <meta name="description" content="Free Access to a Paid Data Platform, Without Giving the Platform Away. A free, public product that converts unfamiliar visitors into paying users.">
 <link rel="icon" href="../favicon.svg" type="image/svg+xml">

--- a/preview/index.html
+++ b/preview/index.html
@@ -13,6 +13,17 @@
 
     gtag('config', 'G-BXLP0J2923');
   </script>
+  <!-- Hotjar Tracking Code for www.dekelhillel.com -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2517369,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>

--- a/transaction-log.html
+++ b/transaction-log.html
@@ -13,6 +13,17 @@
 
     gtag('config', 'G-BXLP0J2923');
   </script>
+  <!-- Hotjar Tracking Code for www.dekelhillel.com -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2517369,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
 <title>Transaction Log — Dekel Hillel</title>
 <meta name="description" content="From JSON Dump to Transaction Lifecycle. Giving operations teams a way to diagnose failures themselves, instead of escalating raw JSON to engineering.">
 <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">

--- a/transaction-log/index.html
+++ b/transaction-log/index.html
@@ -13,6 +13,17 @@
 
     gtag('config', 'G-BXLP0J2923');
   </script>
+  <!-- Hotjar Tracking Code for www.dekelhillel.com -->
+  <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2517369,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel · From JSON Dump to Transaction Lifecycle</title>


### PR DESCRIPTION
Adds the Hotjar tracking snippet (site ID `2517369`) to the `<head>` of every page, placed directly after the Google Analytics block. Exactly one Hotjar tag per page.

Pages covered:
- `index.html`
- `transaction-log/index.html`
- `ownera-investor/index.html`
- `placer-lite/index.html`
- `transaction-log.html` (stale orphan page)
- `preview/index.html` (staging mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_