### PR TITLE
Update hero bio copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>
-  <meta name="description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
+  <meta name="description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://dekelhillel.com/">
@@ -37,7 +37,7 @@
   <meta property="og:url"         content="https://dekelhillel.com/">
   <meta property="og:site_name"   content="Dekel Hillel">
   <meta property="og:title"       content="Dekel Hillel">
-  <meta property="og:description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
+  <meta property="og:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta property="og:image"       content="https://dekelhillel.com/og-image.png">
   <meta property="og:image:width"  content="1200">
   <meta property="og:image:height" content="630">
@@ -47,7 +47,7 @@
   <!-- ── Twitter / X Card ────────────────────────────────────── -->
   <meta name="twitter:card"        content="summary_large_image">
   <meta name="twitter:title"       content="Dekel Hillel">
-  <meta name="twitter:description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
+  <meta name="twitter:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="twitter:image"       content="https://dekelhillel.com/og-image.png">
   <meta name="twitter:image:alt"   content="Dekel Hillel, Product Designer">
 
@@ -67,7 +67,7 @@
     "name": "Dekel Hillel",
     "url": "https://dekelhillel.com",
     "jobTitle": "Product Designer",
-    "description": "I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.",
+    "description": "I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.",
     "sameAs": [
       "https://www.linkedin.com/in/dekelhillel/"
     ],
@@ -757,14 +757,9 @@
     <div class="hero-inner">
       <h1 data-reveal>Dekel Hillel</h1>
       <p class="intro" data-reveal>
-        I'm a product designer who builds the foundations for complex products,<br>
-        most recently leading design at <b>Ownera</b>. <br>
-        Before that, high-scale work at <b>SimilarWeb</b> and <b>Placer.ai</b>.<br>
-        <br>
-        I love taking things from 0 to 1, sweating the details,<br>
-        and helping teams be more ambitious and have fun doing it. <br>
-        <br>
-        I've also taught a UX/UI course at <b>Bezalel Academy of Arts and Design</b>.
+        I'm a Tel Aviv-based product designer specialising in complex, data-heavy products,
+        with a background in graphic design. I'm passionate about crafting beautiful and useful
+        experiences that give people exactly what they need to do more.
       </p>
       <p class="contact-links" data-reveal>
         <a href="mailto:h.dekel@gmail.com">Email</a>

--- a/preview/index.html
+++ b/preview/index.html
@@ -27,7 +27,7 @@
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
   <title>Dekel Hillel</title>
-  <meta name="description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
+  <meta name="description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="noindex, nofollow">
   <link rel="canonical" href="https://dekelhillel.com/">
@@ -37,7 +37,7 @@
   <meta property="og:url"         content="https://dekelhillel.com/">
   <meta property="og:site_name"   content="Dekel Hillel">
   <meta property="og:title"       content="Dekel Hillel">
-  <meta property="og:description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
+  <meta property="og:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta property="og:image"       content="https://dekelhillel.com/og-image.png">
   <meta property="og:image:width"  content="1200">
   <meta property="og:image:height" content="630">
@@ -47,7 +47,7 @@
   <!-- ── Twitter / X Card ────────────────────────────────────── -->
   <meta name="twitter:card"        content="summary_large_image">
   <meta name="twitter:title"       content="Dekel Hillel">
-  <meta name="twitter:description" content="I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.">
+  <meta name="twitter:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="twitter:image"       content="https://dekelhillel.com/og-image.png">
   <meta name="twitter:image:alt"   content="Dekel Hillel, Product Designer">
 
@@ -67,7 +67,7 @@
     "name": "Dekel Hillel",
     "url": "https://dekelhillel.com",
     "jobTitle": "Product Designer",
-    "description": "I'm a product designer who builds the foundations for complex products, most recently leading design at Ownera. Before that, high-scale work at SimilarWeb and Placer.ai. I love taking things from 0 to 1, sweating the details, and helping teams be more ambitious and have fun doing it. I've also taught a UX/UI course at Bezalel Academy of Arts and Design.",
+    "description": "I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.",
     "sameAs": [
       "https://www.linkedin.com/in/dekelhillel/"
     ],
@@ -757,14 +757,9 @@
     <div class="hero-inner">
       <h1 data-reveal>Dekel Hillel</h1>
       <p class="intro" data-reveal>
-        I'm a product designer who builds the foundations for complex products,<br>
-        most recently leading design at <b>Ownera</b>. <br>
-        Before that, high-scale work at <b>SimilarWeb</b> and <b>Placer.ai</b>.<br>
-        <br>
-        I love taking things from 0 to 1, sweating the details,<br>
-        and helping teams be more ambitious and have fun doing it. <br>
-        <br>
-        I've also taught a UX/UI course at <b>Bezalel Academy of Arts and Design</b>.
+        I'm a Tel Aviv-based product designer specialising in complex, data-heavy products,
+        with a background in graphic design. I'm passionate about crafting beautiful and useful
+        experiences that give people exactly what they need to do more.
       </p>
       <p class="contact-links" data-reveal>
         <a href="mailto:h.dekel@gmail.com">Email</a>


### PR DESCRIPTION
Replaces the hero intro paragraph with the new bio:

> I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.

Also updates the matching `meta description`, Open Graph, Twitter card, and JSON-LD descriptions so search/social previews stay in sync. Applied to `index.html` and the `preview/` staging mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_