### PR TITLE
Bold "product designer" in hero intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -757,7 +757,7 @@
     <div class="hero-inner">
       <h1 data-reveal>Dekel Hillel</h1>
       <p class="intro" data-reveal>
-        I'm a Tel Aviv-based product designer specialising in complex, data-heavy products,
+        I'm a Tel Aviv-based <b>product designer</b> specialising in complex, data-heavy products,
         with a background in graphic design. I'm passionate about crafting beautiful and useful
         experiences that give people exactly what they need to do more.
       </p>

--- a/preview/index.html
+++ b/preview/index.html
@@ -757,7 +757,7 @@
     <div class="hero-inner">
       <h1 data-reveal>Dekel Hillel</h1>
       <p class="intro" data-reveal>
-        I'm a Tel Aviv-based product designer specialising in complex, data-heavy products,
+        I'm a Tel Aviv-based <b>product designer</b> specialising in complex, data-heavy products,
         with a background in graphic design. I'm passionate about crafting beautiful and useful
         experiences that give people exactly what they need to do more.
       </p>


### PR DESCRIPTION
Wraps "product designer" in `<b>` in the hero paragraph, matching the emphasis style used for company names before. Applied to `index.html` and the `preview/` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_