### PR TITLE
Align hero text with the work card content column

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,19 +410,17 @@
       display: block;
     }
 
+    /* Hero content shares the work card's 1045px content column so its
+       left edge lines up with the Work label / company names below */
     .hero-inner {
       position: relative;
       z-index: 2;
       display: flex;
       flex-direction: column;
-      align-items: center;
+      align-items: flex-start;
       gap: 40px;
       width: 100%;
-    }
-
-    .hero-inner > * {
-      width: 100%;
-      max-width: 760px;
+      max-width: 1045px;
     }
 
     .hero h1 {
@@ -434,6 +432,7 @@
     }
 
     .hero .intro {
+      max-width: 760px;  /* keeps line length readable within the wider column */
       line-height: 1.6;
       letter-spacing: 0.16px;
       overflow-wrap: break-word;

--- a/preview/index.html
+++ b/preview/index.html
@@ -410,19 +410,17 @@
       display: block;
     }
 
+    /* Hero content shares the work card's 1045px content column so its
+       left edge lines up with the Work label / company names below */
     .hero-inner {
       position: relative;
       z-index: 2;
       display: flex;
       flex-direction: column;
-      align-items: center;
+      align-items: flex-start;
       gap: 40px;
       width: 100%;
-    }
-
-    .hero-inner > * {
-      width: 100%;
-      max-width: 760px;
+      max-width: 1045px;
     }
 
     .hero h1 {
@@ -434,6 +432,7 @@
     }
 
     .hero .intro {
+      max-width: 760px;  /* keeps line length readable within the wider column */
       line-height: 1.6;
       letter-spacing: 0.16px;
       overflow-wrap: break-word;


### PR DESCRIPTION
The hero title, intro, and contact links now share the work card's 1045px content column (left-aligned), so their left edge lines up exactly with the folder icon / "Work" label and company names below — verified in a rendered screenshot (all at the same x position). The intro paragraph keeps a 760px width cap so line length stays readable.

Applied to `index.html` and the `preview/` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_