### PR TITLE
Deliberate line breaks in hero intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,6 +438,12 @@
       overflow-wrap: break-word;
     }
 
+    /* Manual line breaks only where there's room; on narrow screens
+       the text wraps naturally instead */
+    @media (max-width: 900px) {
+      .wide-only { display: none; }
+    }
+
     .hero .intro b {
       font-weight: 700;
     }
@@ -756,9 +762,10 @@
     <div class="hero-inner">
       <h1 data-reveal>Dekel Hillel</h1>
       <p class="intro" data-reveal>
-        I'm a Tel Aviv-based <b>product designer</b> specialising in complex, data-heavy products,
-        with a background in graphic design. I'm passionate about crafting beautiful and useful
-        experiences that give people exactly what they need to do more.
+        I'm a Tel Aviv-based <b>product designer</b> specialising in complex, data-heavy products,<br class="wide-only">
+        with a background in graphic design.<br class="wide-only">
+        I'm passionate about crafting beautiful and useful experiences<br class="wide-only">
+        that give people exactly what they need to do more.
       </p>
       <p class="contact-links" data-reveal>
         <a href="mailto:h.dekel@gmail.com">Email</a>

--- a/preview/index.html
+++ b/preview/index.html
@@ -438,6 +438,12 @@
       overflow-wrap: break-word;
     }
 
+    /* Manual line breaks only where there's room; on narrow screens
+       the text wraps naturally instead */
+    @media (max-width: 900px) {
+      .wide-only { display: none; }
+    }
+
     .hero .intro b {
       font-weight: 700;
     }
@@ -756,9 +762,10 @@
     <div class="hero-inner">
       <h1 data-reveal>Dekel Hillel</h1>
       <p class="intro" data-reveal>
-        I'm a Tel Aviv-based <b>product designer</b> specialising in complex, data-heavy products,
-        with a background in graphic design. I'm passionate about crafting beautiful and useful
-        experiences that give people exactly what they need to do more.
+        I'm a Tel Aviv-based <b>product designer</b> specialising in complex, data-heavy products,<br class="wide-only">
+        with a background in graphic design.<br class="wide-only">
+        I'm passionate about crafting beautiful and useful experiences<br class="wide-only">
+        that give people exactly what they need to do more.
       </p>
       <p class="contact-links" data-reveal>
         <a href="mailto:h.dekel@gmail.com">Email</a>


### PR DESCRIPTION
Fixes the dangling "with a" at the end of the first line. The intro now breaks into four deliberate lines on wide screens:

1. I'm a Tel Aviv-based **product designer** specialising in complex, data-heavy products,
2. with a background in graphic design.
3. I'm passionate about crafting beautiful and useful experiences
4. that give people exactly what they need to do more.

The breaks (`<br class="wide-only">`) are hidden below 900px so mobile/tablet keeps natural wrapping. Verified with rendered screenshots at 1440px and 390px. Applied to `index.html` and the `preview/` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_