### PR TITLE
Rename homepage title to "Dekel Hillel - Portfolio"

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
   </script>
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
-  <title>Dekel Hillel</title>
+  <title>Dekel Hillel - Portfolio</title>
   <meta name="description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="index, follow">
@@ -36,7 +36,7 @@
   <meta property="og:type"        content="website">
   <meta property="og:url"         content="https://dekelhillel.com/">
   <meta property="og:site_name"   content="Dekel Hillel">
-  <meta property="og:title"       content="Dekel Hillel">
+  <meta property="og:title"       content="Dekel Hillel - Portfolio">
   <meta property="og:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta property="og:image"       content="https://dekelhillel.com/og-image.png">
   <meta property="og:image:width"  content="1200">
@@ -46,7 +46,7 @@
 
   <!-- ── Twitter / X Card ────────────────────────────────────── -->
   <meta name="twitter:card"        content="summary_large_image">
-  <meta name="twitter:title"       content="Dekel Hillel">
+  <meta name="twitter:title"       content="Dekel Hillel - Portfolio">
   <meta name="twitter:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="twitter:image"       content="https://dekelhillel.com/og-image.png">
   <meta name="twitter:image:alt"   content="Dekel Hillel, Product Designer">

--- a/preview/index.html
+++ b/preview/index.html
@@ -26,7 +26,7 @@
   </script>
 
   <!-- ── Primary SEO ─────────────────────────────────────────── -->
-  <title>Dekel Hillel</title>
+  <title>Dekel Hillel - Portfolio</title>
   <meta name="description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="author" content="Dekel Hillel">
   <meta name="robots" content="noindex, nofollow">
@@ -36,7 +36,7 @@
   <meta property="og:type"        content="website">
   <meta property="og:url"         content="https://dekelhillel.com/">
   <meta property="og:site_name"   content="Dekel Hillel">
-  <meta property="og:title"       content="Dekel Hillel">
+  <meta property="og:title"       content="Dekel Hillel - Portfolio">
   <meta property="og:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta property="og:image"       content="https://dekelhillel.com/og-image.png">
   <meta property="og:image:width"  content="1200">
@@ -46,7 +46,7 @@
 
   <!-- ── Twitter / X Card ────────────────────────────────────── -->
   <meta name="twitter:card"        content="summary_large_image">
-  <meta name="twitter:title"       content="Dekel Hillel">
+  <meta name="twitter:title"       content="Dekel Hillel - Portfolio">
   <meta name="twitter:description" content="I'm a Tel Aviv-based product designer specialising in complex, data-heavy products, with a background in graphic design. I'm passionate about crafting beautiful and useful experiences that give people exactly what they need to do more.">
   <meta name="twitter:image"       content="https://dekelhillel.com/og-image.png">
   <meta name="twitter:image:alt"   content="Dekel Hillel, Product Designer">


### PR DESCRIPTION
Changes the homepage browser-tab title from "Dekel Hillel" to "Dekel Hillel - Portfolio", and updates `og:title` / `twitter:title` to match so social link previews stay in sync. Case-study pages keep their "Dekel Hillel · &lt;case study&gt;" format. Applied to `index.html` and the `preview/` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyzZrAHdaxWtuJDy4v6JB)_